### PR TITLE
fix for text overflow in dataset and username

### DIFF
--- a/ga4gh/server/static/dashboard.css
+++ b/ga4gh/server/static/dashboard.css
@@ -191,3 +191,16 @@
     left: 0;
     right: 0;
 }
+
+.dropdown-toggle .text {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  max-width: 100%;
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.dropdown-toggle {
+    white-space: nowrap;
+}


### PR DESCRIPTION
Use `text-overflow: ellipsis;` to prevent text overflow