### PR TITLE
load and return attributes for metadata

### DIFF
--- a/ga4gh/server/datamodel/__init__.py
+++ b/ga4gh/server/datamodel/__init__.py
@@ -793,7 +793,7 @@ class DatamodelObject(object):
         Return True if the access level is higher than the required, False otherwise.
         """
 
-        if "Tier" in attribute_name:
+        if attribute_name.endswith("Tier"):
             return False
 
         else:

--- a/ga4gh/server/datamodel/__init__.py
+++ b/ga4gh/server/datamodel/__init__.py
@@ -788,6 +788,44 @@ class DatamodelObject(object):
         else:
             self._attributes = {}
 
+    def validateAttribute(self, attribute_name, attributes, tier=0):
+        """
+        Return True if the access level is higher than the required, False otherwise.
+        """
+
+        if "Tier" in attribute_name:
+            return False
+
+        else:
+            attrTierObj = attributes.get(attribute_name + 'Tier', None)
+
+            if attrTierObj is not None:
+                attrTier = attrTierObj[0].get('int32Value', None)
+
+            if attrTierObj is None or attrTier is None or tier < attrTier:
+                return False
+
+            else:
+                return True
+
+    def serializeMetadataAttributes(self, msg, tier=0):
+        """
+        Sets the attrbutes of a message for metadata during serialization.
+        """
+        attributes = self.getAttributes()
+
+        for attribute_name in attributes:
+            if self.validateAttribute(attribute_name, attributes, tier) is True:
+                values = []
+                for dictionary in attributes[attribute_name]:
+                    for key in dictionary:
+                        values.append(dictionary[key])
+
+                protocol.setAttribute(
+                    msg.attributes.attr[attribute_name].values, values)
+
+        return msg
+
     def serializeAttributes(self, msg):
         """
         Sets the attrbutes of a message during serialization.

--- a/ga4gh/server/datamodel/clinical_metadata.py
+++ b/ga4gh/server/datamodel/clinical_metadata.py
@@ -145,7 +145,7 @@ class Patient(datamodel.DatamodelObject):
             record[str('occupationalOrEnvironmentalExposure')] = str(self.getOccupationalOrEnvironmentalExposure())
 
         Patient = protocol.Patient(**record)
-        self.serializeAttributes(Patient)
+        self.serializeMetadataAttributes(Patient)
 
         return Patient
 
@@ -211,8 +211,7 @@ class Patient(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields
@@ -498,7 +497,7 @@ class Enrollment(datamodel.DatamodelObject):
             record[str('treatingCentreProvince')] = str(self.getTreatingCentreProvince())
 
         Enrollment = protocol.Enrollment(**record)
-        self.serializeAttributes(Enrollment)
+        self.serializeMetadataAttributes(Enrollment)
 
         return Enrollment
 
@@ -560,8 +559,7 @@ class Enrollment(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields
@@ -852,7 +850,7 @@ class Consent(datamodel.DatamodelObject):
             record[str('consentFormComplete')] = str(self.getConsentFormComplete())
 
         Consent = protocol.Consent(**record)
-        self.serializeAttributes(Consent)
+        self.serializeMetadataAttributes(Consent)
 
         return Consent
 
@@ -922,8 +920,7 @@ class Consent(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields
@@ -1291,7 +1288,7 @@ class Diagnosis(datamodel.DatamodelObject):
             record[str('additionalTest')] = str(self.getAdditionalTest())
 
         Diagnosis = protocol.Diagnosis(**record)
-        self.serializeAttributes(Diagnosis)
+        self.serializeMetadataAttributes(Diagnosis)
 
         return Diagnosis
 
@@ -1379,8 +1376,7 @@ class Diagnosis(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields
@@ -1805,7 +1801,7 @@ class Sample(datamodel.DatamodelObject):
             record[str('startInterval')] = str(self.getStartInterval())
 
         Sample = protocol.Sample(**record)
-        self.serializeAttributes(Sample)
+        self.serializeMetadataAttributes(Sample)
 
         return Sample
 
@@ -1887,8 +1883,7 @@ class Sample(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields
@@ -2229,7 +2224,7 @@ class Treatment(datamodel.DatamodelObject):
             record[str('treatmentPlanId')] = str(self.getTreatmentPlanId())
 
         Treatment = protocol.Treatment(**record)
-        self.serializeAttributes(Treatment)
+        self.serializeMetadataAttributes(Treatment)
 
         return Treatment
 
@@ -2287,8 +2282,7 @@ class Treatment(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields
@@ -2553,7 +2547,7 @@ class Outcome(datamodel.DatamodelObject):
             record[str('diseaseFreeSurvivalInMonths')] = str(self.getDiseaseFreeSurvivalInMonths())
 
         Outcome = protocol.Outcome(**record)
-        self.serializeAttributes(Outcome)
+        self.serializeMetadataAttributes(Outcome)
 
         return Outcome
 
@@ -2619,8 +2613,7 @@ class Outcome(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields
@@ -2857,7 +2850,7 @@ class Complication(datamodel.DatamodelObject):
             record[str('treatmentInducedNeoplasmDetails')] = str(self.getTreatmentInducedNeoplasmDetails())
 
         Complication = protocol.Complication(**record)
-        self.serializeAttributes(Complication)
+        self.serializeMetadataAttributes(Complication)
 
         return Complication
 
@@ -2899,8 +2892,7 @@ class Complication(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields
@@ -3161,7 +3153,7 @@ class Tumourboard(datamodel.DatamodelObject):
             record[str('summaryReport')] = str(self.getSummaryReport())
 
         Tumourboard = protocol.Tumourboard(**record)
-        self.serializeAttributes(Tumourboard)
+        self.serializeMetadataAttributes(Tumourboard)
         
         return Tumourboard
 
@@ -3251,8 +3243,7 @@ class Tumourboard(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields
@@ -3640,7 +3631,7 @@ class Chemotherapy(datamodel.DatamodelObject):
             record[str('treatmentPlanId')] = str(self.getTreatmentPlanId())
 
         Chemotherapy = protocol.Chemotherapy(**record)
-        self.serializeAttributes(Chemotherapy)
+        self.serializeMetadataAttributes(Chemotherapy, tier)
 
         return Chemotherapy
 
@@ -3689,6 +3680,7 @@ class Chemotherapy(datamodel.DatamodelObject):
         self._treatmentPlanId = ChemotherapyRecord.treatmentPlanId
         self._treatmentPlanIdTier = ChemotherapyRecord.treatmentPlanIdTier
 
+
         return self
 
     def populateFromJson(self, jsonString):
@@ -3704,8 +3696,7 @@ class Chemotherapy(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields
@@ -4033,7 +4024,7 @@ class Radiotherapy(datamodel.DatamodelObject):
             record[str('boostDose')] = str(self.getBoostDose())
 
         Radiotherapy = protocol.Radiotherapy(**record)
-        self.serializeAttributes(Radiotherapy)
+        self.serializeMetadataAttributes(Radiotherapy)
 
         return Radiotherapy
 
@@ -4115,8 +4106,7 @@ class Radiotherapy(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields
@@ -4442,7 +4432,7 @@ class Surgery(datamodel.DatamodelObject):
             record[str('courseNumber')] = str(self.getCourseNumber())
 
         Surgery = protocol.Surgery(**record)
-        self.serializeAttributes(Surgery)
+        self.serializeMetadataAttributes(Surgery)
 
         return Surgery
 
@@ -4494,8 +4484,7 @@ class Surgery(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields
@@ -4681,7 +4670,7 @@ class Immunotherapy(datamodel.DatamodelObject):
             record[str('courseNumber')] = str(self.getCourseNumber())
 
         Immunotherapy = protocol.Immunotherapy(**record)
-        self.serializeAttributes(Immunotherapy)
+        self.serializeMetadataAttributes(Immunotherapy)
 
         return Immunotherapy
 
@@ -4725,8 +4714,7 @@ class Immunotherapy(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields
@@ -4875,7 +4863,7 @@ class Celltransplant(datamodel.DatamodelObject):
             record[str('courseNumber')] = str(self.getCourseNumber())
 
         Celltransplant = protocol.Celltransplant(**record)
-        self.serializeAttributes(Celltransplant)
+        self.serializeMetadataAttributes(Celltransplant)
 
         return Celltransplant
 
@@ -4917,8 +4905,7 @@ class Celltransplant(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields
@@ -5114,7 +5101,7 @@ class Slide(datamodel.DatamodelObject):
             record[str('sectionLocation')] = str(self.getSectionLocation())
 
         Slide = protocol.Slide(**record)
-        self.serializeAttributes(Slide)
+        self.serializeMetadataAttributes(Slide)
 
         return Slide
 
@@ -5178,8 +5165,7 @@ class Slide(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields
@@ -5403,7 +5389,7 @@ class Study(datamodel.DatamodelObject):
             record[str('recordingDate')] = str(self.getRecordingDate())
 
         Study = protocol.Study(**record)
-        self.serializeAttributes(Study)
+        self.serializeMetadataAttributes(Study)
 
         return Study
 
@@ -5443,8 +5429,7 @@ class Study(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields
@@ -5587,7 +5572,7 @@ class Labtest(datamodel.DatamodelObject):
             record[str('recordingDate')] = str(self.getRecordingDate())
 
         Labtest = protocol.Labtest(**record)
-        self.serializeAttributes(Labtest)
+        self.serializeMetadataAttributes(Labtest)
 
         return Labtest
 
@@ -5633,8 +5618,7 @@ class Labtest(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields

--- a/ga4gh/server/datamodel/clinical_metadata.py
+++ b/ga4gh/server/datamodel/clinical_metadata.py
@@ -3680,7 +3680,6 @@ class Chemotherapy(datamodel.DatamodelObject):
         self._treatmentPlanId = ChemotherapyRecord.treatmentPlanId
         self._treatmentPlanIdTier = ChemotherapyRecord.treatmentPlanIdTier
 
-
         return self
 
     def populateFromJson(self, jsonString):

--- a/ga4gh/server/datamodel/pipeline_metadata.py
+++ b/ga4gh/server/datamodel/pipeline_metadata.py
@@ -89,7 +89,7 @@ class Extraction(datamodel.DatamodelObject):
             record[str('site')] = str(self.getSite())
 
         Extraction = protocol.Extraction(**record)
-        self.serializeAttributes(Extraction)
+        self.serializeMetadataAttributes(Extraction)
 
         return Extraction
 
@@ -133,8 +133,7 @@ class Extraction(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields
@@ -306,7 +305,7 @@ class Sequencing(datamodel.DatamodelObject):
             record[str('site')] = str(self.getSite())
 
         Sequencing = protocol.Sequencing(**record)
-        self.serializeAttributes(Sequencing)
+        self.serializeMetadataAttributes(Sequencing)
 
         return Sequencing
 
@@ -358,8 +357,7 @@ class Sequencing(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields
@@ -598,7 +596,7 @@ class Alignment(datamodel.DatamodelObject):
             record[str('site')] = str(self.getSite())
 
         Alignment = protocol.Alignment(**record)
-        self.serializeAttributes(Alignment)
+        self.serializeMetadataAttributes(Alignment)
 
         return Alignment
 
@@ -664,8 +662,7 @@ class Alignment(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields
@@ -943,7 +940,7 @@ class VariantCalling(datamodel.DatamodelObject):
             record[str('site')] = str(self.getSite())
 
         VariantCalling = protocol.VariantCalling(**record)
-        self.serializeAttributes(VariantCalling)
+        self.serializeMetadataAttributes(VariantCalling)
 
         return VariantCalling
 
@@ -1003,8 +1000,7 @@ class VariantCalling(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields
@@ -1240,7 +1236,7 @@ class FusionDetection(datamodel.DatamodelObject):
             record[str('site')] = str(self.getSite())
 
         FusionDetection = protocol.FusionDetection(**record)
-        self.serializeAttributes(FusionDetection)
+        self.serializeMetadataAttributes(FusionDetection)
 
         return FusionDetection
 
@@ -1292,8 +1288,7 @@ class FusionDetection(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields
@@ -1487,7 +1482,7 @@ class ExpressionAnalysis(datamodel.DatamodelObject):
             record[str('site')] = str(self.getSite())
 
         ExpressionAnalysis = protocol.ExpressionAnalysis(**record)
-        self.serializeAttributes(ExpressionAnalysis)
+        self.serializeMetadataAttributes(ExpressionAnalysis)
 
         return ExpressionAnalysis
 
@@ -1535,8 +1530,7 @@ class ExpressionAnalysis(datamodel.DatamodelObject):
         self._description = parsed.description
         attributes = {}
         for key in parsed.attributes.attr:
-            attributes[key] = {
-                "values": protocol.toJsonDict(parsed.attributes.attr[key])}
+            attributes[key] = protocol.toJsonDict(parsed.attributes.attr[key])['values']
         self.setAttributes(attributes)
 
         # Unique fields

--- a/ga4gh/server/datarepo.py
+++ b/ga4gh/server/datarepo.py
@@ -1813,6 +1813,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=patient.getUpdated(),
                 name=patient.getLocalId(),
                 description=patient.getDescription(),
+                attributes=json.dumps(patient.getAttributes()),
                 # Unique fields
                 patientId = patient.getPatientId(),
                 patientIdTier = patient.getPatientIdTier(),
@@ -1884,6 +1885,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=enrollment.getUpdated(),
                 name=enrollment.getLocalId(),
                 description=enrollment.getDescription(),
+                attributes=json.dumps(enrollment.getAttributes()),
 
                 # Unique fields
                 patientId = enrollment.getPatientId(),
@@ -1952,6 +1954,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=consent.getUpdated(),
                 name=consent.getLocalId(),
                 description=consent.getDescription(),
+                attributes=json.dumps(consent.getAttributes()),
 
                 # Unique fields
                 patientId = consent.getPatientId(),
@@ -2028,6 +2031,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=diagnosis.getUpdated(),
                 name=diagnosis.getLocalId(),
                 description=diagnosis.getDescription(),
+                attributes=json.dumps(diagnosis.getAttributes()),
 
                 # Unique fields
                 patientId = diagnosis.getPatientId(),
@@ -2122,6 +2126,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=sample.getUpdated(),
                 name=sample.getLocalId(),
                 description=sample.getDescription(),
+                attributes=json.dumps(sample.getAttributes()),
 
                 # Unique fields
                 patientId = sample.getPatientId(),
@@ -2206,6 +2211,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=treatment.getUpdated(),
                 name=treatment.getLocalId(),
                 description=treatment.getDescription(),
+                attributes=json.dumps(treatment.getAttributes()),
 
                 # Unique fields
                 patientId = treatment.getPatientId(),
@@ -2266,6 +2272,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=outcome.getUpdated(),
                 name=outcome.getLocalId(),
                 description=outcome.getDescription(),
+                attributes=json.dumps(outcome.getAttributes()),
 
                 # Unique fields
                 patientId = outcome.getPatientId(),
@@ -2334,6 +2341,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=complication.getUpdated(),
                 name=complication.getLocalId(),
                 description=complication.getDescription(),
+                attributes=json.dumps(complication.getAttributes()),
 
                 # Unique fields
                 patientId = complication.getPatientId(),
@@ -2382,6 +2390,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=tumourboard.getUpdated(),
                 name=tumourboard.getLocalId(),
                 description=tumourboard.getDescription(),
+                attributes=json.dumps(tumourboard.getAttributes()),
 
                 # Unique fields
                 patientId = tumourboard.getPatientId(),
@@ -2478,6 +2487,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=chemotherapy.getUpdated(),
                 name=chemotherapy.getLocalId(),
                 description=chemotherapy.getDescription(),
+                attributes=json.dumps(chemotherapy.getAttributes()),
 
                 # Unique fields
                 patientId=chemotherapy.getPatientId(),
@@ -2548,6 +2558,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=radiotherapy.getUpdated(),
                 name=radiotherapy.getLocalId(),
                 description=radiotherapy.getDescription(),
+                attributes=json.dumps(radiotherapy.getAttributes()),
 
                 # Unique fields
                 patientId=radiotherapy.getPatientId(),
@@ -2637,6 +2648,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=surgery.getUpdated(),
                 name=surgery.getLocalId(),
                 description=surgery.getDescription(),
+                attributes=json.dumps(surgery.getAttributes()),
 
                 # Unique fields
                 patientId=surgery.getPatientId(),
@@ -2696,6 +2708,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=immunotherapy.getUpdated(),
                 name=immunotherapy.getLocalId(),
                 description=immunotherapy.getDescription(),
+                attributes=json.dumps(immunotherapy.getAttributes()),
 
                 # Unique fields
                 patientId=immunotherapy.getPatientId(),
@@ -2747,6 +2760,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=celltransplant.getUpdated(),
                 name=celltransplant.getLocalId(),
                 description=celltransplant.getDescription(),
+                attributes=json.dumps(celltransplant.getAttributes()),
 
                 # Unique fields
                 patientId=celltransplant.getPatientId(),
@@ -2796,6 +2810,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=slide.getUpdated(),
                 name=slide.getLocalId(),
                 description=slide.getDescription(),
+                attributes=json.dumps(slide.getAttributes()),
 
                 # Unique fields
                 patientId=slide.getPatientId(),
@@ -2867,6 +2882,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=study.getUpdated(),
                 name=study.getLocalId(),
                 description=study.getDescription(),
+                attributes=json.dumps(study.getAttributes()),
 
                 # Unique fields
                 patientId=study.getPatientId(),
@@ -2914,6 +2930,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=labtest.getUpdated(),
                 name=labtest.getLocalId(),
                 description=labtest.getDescription(),
+                attributes=json.dumps(labtest.getAttributes()),
 
                 # Unique fields
                 patientId=labtest.getPatientId(),
@@ -2967,6 +2984,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=extraction.getUpdated(),
                 name=extraction.getLocalId(),
                 description=extraction.getDescription(),
+                attributes=json.dumps(extraction.getAttributes()),
                 # Unique fields
                 extractionId=extraction.getExtractionId(),
                 extractionIdTier=extraction.getExtractionIdTier(),
@@ -3016,6 +3034,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=sequencing.getUpdated(),
                 name=sequencing.getLocalId(),
                 description=sequencing.getDescription(),
+                attributes=json.dumps(sequencing.getAttributes()),
                 # Unique fields
                 sequencingId=sequencing.getSequencingId(),
                 sequencingIdTier=sequencing.getSequencingIdTier(),
@@ -3073,6 +3092,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=alignment.getUpdated(),
                 name=alignment.getLocalId(),
                 description=alignment.getDescription(),
+                attributes=json.dumps(alignment.getAttributes()),
                 # Unique fields
                 alignmentId=alignment.getAlignmentId(),
                 alignmentIdTier=alignment.getAlignmentIdTier(),
@@ -3142,6 +3162,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=variantCalling.getUpdated(),
                 name=variantCalling.getLocalId(),
                 description=variantCalling.getDescription(),
+                attributes=json.dumps(variantCalling.getAttributes()),
                 # Unique fields
                 variantCallingId=variantCalling.getVariantCallingId(),
                 variantCallingIdTier=variantCalling.getVariantCallingIdTier(),
@@ -3206,6 +3227,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=fusionDetection.getUpdated(),
                 name=fusionDetection.getLocalId(),
                 description=fusionDetection.getDescription(),
+                attributes=json.dumps(fusionDetection.getAttributes()),
                 # Unique fields
                 fusionDetectionId=fusionDetection.getFusionDetectionId(),
                 fusionDetectionIdTier=fusionDetection.getFusionDetectionIdTier(),
@@ -3263,6 +3285,7 @@ class SqlDataRepository(AbstractDataRepository):
                 updated=expressionAnalysis.getUpdated(),
                 name=expressionAnalysis.getLocalId(),
                 description=expressionAnalysis.getDescription(),
+                attributes=json.dumps(expressionAnalysis.getAttributes()),
                 # Unique fields
                 expressionAnalysisId=expressionAnalysis.getExpressionAnalysisId(),
                 expressionAnalysisIdTier=expressionAnalysis.getExpressionAnalysisIdTier(),


### PR DESCRIPTION
This PR introduces the ability to add custom attributes data to the metadata tables

- A serializer for metadata attributes to preserve backward compatibilities
- Additional `attribute` field when the peewee model was created