### PR TITLE
Feature 190423 update package naming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ install:
 before_script:
   - pip install -r dev-requirements.txt
   - python scripts/build_test_data.py
-  - PROFYLE_ingest --version
-  - PROFYLE_ingest tests/data/registry.db dataset1 tests/data/sample_clin_metadata.json
-  - PROFYLE_ingest tests/data/registry.db dataset1 tests/data/sample_pipe_metadata.json
+  - ingest --version
+  - ingest tests/data/registry.db dataset1 tests/data/sample_clin_metadata.json
+  - ingest tests/data/registry.db dataset1 tests/data/sample_pipe_metadata.json
     
 before_install:
     - bash tools/travis-install-protoc.sh 3.3.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - easy_install distribute
   - pip install --upgrade distribute
   - python setup.py sdist
-  - pip install dist/ga4gh*.tar.gz -c constraints.txt
+  - pip install dist/candig*.tar.gz -c constraints.txt
 # every installable in setup.py's entry_points should be tested here
   - ga4gh_configtest --version
   - ga4gh_server --version

--- a/README.pypi.rst
+++ b/README.pypi.rst
@@ -1,23 +1,5 @@
-
-.. image:: http://genomicsandhealth.org/files/logo_ga.png
-
 ==============================
-GA4GH Reference Implementation
+CanDIG Server Implementation
 ==============================
 
-This is the GA4GH reference implementation.
-
-Full documentation is available at `read-the-docs.org
-<http://ga4gh-server.readthedocs.org/en/stable>`_.
-
-- For a quick start with the GA4GH API, please see our
-  `demo <http://ga4gh-server.readthedocs.org/en/stable/demo.html>`_.
-- To configure and deploy the GA4GH server in production
-  please see the
-  `installation
-  <http://ga4gh-server.readthedocs.org/en/stable/installation.html>`_
-  page.
-- If you would like to contribute to the project, please see the
-  `development
-  <http://ga4gh-server.readthedocs.org/en/stable/development.html>`_
-  page.
+This is the CanDIG Server reference implementation.

--- a/README.txt
+++ b/README.txt
@@ -1,42 +1,13 @@
-
-.. image:: http://genomicsandhealth.org/files/logo_ga.png
-
 ==============================
-GA4GH Reference Implementation
+CanDIG Server
 ==============================
 
-.. image:: https://readthedocs.org/projects/ga4gh-server/badge/?version=latest
-   :target: http://ga4gh-server.readthedocs.io/en/latest/?badge=latest
-   :alt: Documentation Status
-
-.. image:: https://img.shields.io/travis/CanDIG/ga4gh-server/master.svg
+.. image:: https://img.shields.io/travis/CanDIG/candig-server/master.svg
    :alt: Current build status on Travis-CI, click for more
-   :target: https://travis-ci.org/CanDIG/ga4gh-server
+   :target: https://travis-ci.org/CanDIG/candig-server
 
-.. image:: https://img.shields.io/codecov/c/github/CanDIG/ga4gh-server/master.svg
+.. image:: https://img.shields.io/codecov/c/github/CanDIG/candig-server/master.svg
    :alt: Current code coverage of master branch, click for details
-   :target: https://codecov.io/CanDIG/ga4gh/ga4gh-server
+   :target: https://codecov.io/gh/CanDIG/candig-server
 
-This is the development version of the GA4GH reference implementation.
-If you would like to install the stable version of the server, please
-see the instructions on `the PyPI page <https://pypi.python.org/pypi/ga4gh>`_.
-
-The server is currently under heavy development, and many aspects of
-the layout and APIs will change as requirements are better understood.
-If you would like to help, please check out our list of
-`issues <https://github.com/ga4gh/ga4gh-server/issues>`_!
-
-The latest bleeding-edge documentation is available at `read-the-docs.org
-<http://ga4gh-server.readthedocs.org/en/latest>`_.
-
-- For a quick start with the GA4GH API, please see our
-  `demo <http://ga4gh-server.readthedocs.org/en/latest/demo.html>`_.
-- To configure and deploy the GA4GH server in production
-  please see the
-  `installation
-  <http://ga4gh-server.readthedocs.org/en/latest/installation.html>`_
-  page.
-- If you would like to contribute to the project, please see the
-  `development
-  <http://ga4gh-server.readthedocs.org/en/latest/development.html>`_
-  page.
+This is the development version of the CanDIG Server implementation.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -35,4 +35,4 @@ cherrypy==3.2.4
 yubico-client==1.9.1
 
 # For ingesting various metadata
-git+git://github.com/CanDIG/PROFYLE_ingest.git@develop#egg=PROFYLE_ingest
+git+git://github.com/CanDIG/candig-ingest.git@v1.1.0

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ except EnvironmentError:
 
 setup(
     name="candig-server",
-    description="Flask server implementation of the GA4GH API",
+    description="Server implementation of the CanDIG APIs",
     packages=["ga4gh", "ga4gh.server", "ga4gh.server.datamodel",
               "ga4gh.server.templates"],
     namespace_packages=["ga4gh"],

--- a/setup.py
+++ b/setup.py
@@ -39,13 +39,13 @@ except EnvironmentError:
           'creating dependency links.')
 
 setup(
-    name="ga4gh-server",
-    description="A reference implementation of the GA4GH API",
+    name="candig-server",
+    description="Flask server implementation of the GA4GH API",
     packages=["ga4gh", "ga4gh.server", "ga4gh.server.datamodel",
               "ga4gh.server.templates"],
     namespace_packages=["ga4gh"],
     zip_safe=False,
-    url="https://github.com/ga4gh/ga4gh-server",
+    url="https://github.com/CanDIG/candig-server",
     use_scm_version={"write_to": "ga4gh/server/_version.py"},
     entry_points={
         'console_scripts': [
@@ -59,8 +59,8 @@ setup(
     dependency_links=dependency_links,
     license='Apache License 2.0',
     include_package_data=True,
-    author="Global Alliance for Genomics and Health",
-    author_email="theglobalalliance@genomicsandhealth.org",
+    author="CanDIG Team",
+    author_email="info@distributedgenomics.ca",
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Science/Research',
@@ -69,7 +69,7 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Topic :: Scientific/Engineering :: Bio-Informatics',
     ],
-    keywords=['genomics', 'reference'],
+    keywords=['genomics', 'candig'],
     # Use setuptools_scm to set the version number automatically from Git
     setup_requires=['setuptools_scm'],
 )


### PR DESCRIPTION
- Update setup.py and its package name
- Update package metadata, including authors
- Clean up readme, this includes removing out-of-date content, as well as updating the links to the travis and codecov packages..

- TODO: Do we need to rename the commands, such as from ga4gh-server, ga4gh_repo to candig-server and candig_repo..?
Potential solution: we can add the support of `candig-server` and `candig_repo`, and officially deprecate the old commands starting from the next release.
Timeline: Next PR