### PR TITLE
update server commands, and its respective travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,9 @@ install:
   - python setup.py sdist
   - pip install dist/candig*.tar.gz -c constraints.txt
 # every installable in setup.py's entry_points should be tested here
-  - ga4gh_configtest --version
-  - ga4gh_server --version
-  - ga4gh_repo --version
+  - candig_configtest --version
+  - candig_server --version
+  - candig_repo --version
 
 before_script:
   - pip install -r dev-requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,9 @@ setup(
             'ga4gh_configtest=ga4gh.server.cli.configtest:configtest_main',
             'ga4gh_server=ga4gh.server.cli.server:server_main',
             'ga4gh_repo=ga4gh.server.cli.repomanager:repo_main',
+            'candig_configtest=ga4gh.server.cli.configtest:configtest_main',
+            'candig_server=ga4gh.server.cli.server:server_main',
+            'candig_repo=ga4gh.server.cli.repomanager:repo_main'
         ]
     },
     long_description=long_description,


### PR DESCRIPTION
- Adding new server commands, including `candig_configtest`, `candig_server` and `candig_repo`.
- Deprecating old server commands, including `ga4gh_configtest`, `ga4gh_server` and `ga4gh_repo`, they are still preserved for backward compatibility reasons.

* Next Step:
The next PR will be introducing the change of name space.