### PR TITLE
Test bugfix 190607

### DIFF
--- a/candig/server/backend.py
+++ b/candig/server/backend.py
@@ -10,7 +10,7 @@ import candig.server.datamodel as datamodel
 import candig.server.exceptions as exceptions
 import candig.server.paging as paging
 import candig.server.response_builder as response_builder
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 import operator
 from google.protobuf.json_format import MessageToDict
 import json

--- a/candig/server/backend.py
+++ b/candig/server/backend.py
@@ -10,7 +10,7 @@ import candig.server.datamodel as datamodel
 import candig.server.exceptions as exceptions
 import candig.server.paging as paging
 import candig.server.response_builder as response_builder
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 import operator
 from google.protobuf.json_format import MessageToDict
 import json

--- a/candig/server/cli/__init__.py
+++ b/candig/server/cli/__init__.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 
 import candig.server
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 def addVersionArgument(parser):

--- a/candig/server/cli/__init__.py
+++ b/candig/server/cli/__init__.py
@@ -7,7 +7,7 @@ from __future__ import unicode_literals
 
 import candig.server
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 def addVersionArgument(parser):

--- a/candig/server/datamodel/__init__.py
+++ b/candig/server/datamodel/__init__.py
@@ -16,7 +16,7 @@ import difflib
 
 import candig.server.exceptions as exceptions
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 class PysamFileHandleCache(object):

--- a/candig/server/datamodel/__init__.py
+++ b/candig/server/datamodel/__init__.py
@@ -16,7 +16,7 @@ import difflib
 
 import candig.server.exceptions as exceptions
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 class PysamFileHandleCache(object):

--- a/candig/server/datamodel/bio_metadata.py
+++ b/candig/server/datamodel/bio_metadata.py
@@ -11,7 +11,7 @@ import json
 import candig.server.datamodel as datamodel
 import candig.server.exceptions as exceptions
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 class Biosample(datamodel.DatamodelObject):

--- a/candig/server/datamodel/bio_metadata.py
+++ b/candig/server/datamodel/bio_metadata.py
@@ -11,7 +11,7 @@ import json
 import candig.server.datamodel as datamodel
 import candig.server.exceptions as exceptions
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 class Biosample(datamodel.DatamodelObject):

--- a/candig/server/datamodel/clinical_metadata.py
+++ b/candig/server/datamodel/clinical_metadata.py
@@ -14,7 +14,7 @@ import datetime
 import candig.server.datamodel as datamodel
 import candig.server.exceptions as exceptions
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 class Patient(datamodel.DatamodelObject):

--- a/candig/server/datamodel/clinical_metadata.py
+++ b/candig/server/datamodel/clinical_metadata.py
@@ -14,7 +14,7 @@ import datetime
 import candig.server.datamodel as datamodel
 import candig.server.exceptions as exceptions
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 class Patient(datamodel.DatamodelObject):

--- a/candig/server/datamodel/continuous.py
+++ b/candig/server/datamodel/continuous.py
@@ -18,8 +18,8 @@ import subprocess
 
 import candig.server.datamodel as datamodel
 import candig.server.exceptions as exceptions
-import ga4gh.schemas.pb as pb
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.pb as pb
+import candig.schemas.protocol as protocol
 
 
 """

--- a/candig/server/datamodel/continuous.py
+++ b/candig/server/datamodel/continuous.py
@@ -18,8 +18,8 @@ import subprocess
 
 import candig.server.datamodel as datamodel
 import candig.server.exceptions as exceptions
-import candig.schemas.pb as pb
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.pb as pb
+import ga4gh.schemas.protocol as protocol
 
 
 """

--- a/candig/server/datamodel/datasets.py
+++ b/candig/server/datamodel/datasets.py
@@ -15,8 +15,8 @@ import candig.server.datamodel.bio_metadata as biodata
 import candig.server.datamodel.genotype_phenotype as g2p
 import candig.server.datamodel.rna_quantification as rnaQuantification
 
-import ga4gh.schemas.pb as pb
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.pb as pb
+import candig.schemas.protocol as protocol
 
 
 class Dataset(datamodel.DatamodelObject):

--- a/candig/server/datamodel/datasets.py
+++ b/candig/server/datamodel/datasets.py
@@ -15,8 +15,8 @@ import candig.server.datamodel.bio_metadata as biodata
 import candig.server.datamodel.genotype_phenotype as g2p
 import candig.server.datamodel.rna_quantification as rnaQuantification
 
-import candig.schemas.pb as pb
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.pb as pb
+import ga4gh.schemas.protocol as protocol
 
 
 class Dataset(datamodel.DatamodelObject):

--- a/candig/server/datamodel/genotype_phenotype.py
+++ b/candig/server/datamodel/genotype_phenotype.py
@@ -12,7 +12,7 @@ import rdflib
 import candig.server.datamodel as datamodel
 import candig.server.exceptions as exceptions
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 # annotation keys
 TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'

--- a/candig/server/datamodel/genotype_phenotype.py
+++ b/candig/server/datamodel/genotype_phenotype.py
@@ -12,7 +12,7 @@ import rdflib
 import candig.server.datamodel as datamodel
 import candig.server.exceptions as exceptions
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 # annotation keys
 TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'

--- a/candig/server/datamodel/genotype_phenotype_featureset.py
+++ b/candig/server/datamodel/genotype_phenotype_featureset.py
@@ -15,7 +15,7 @@ import candig.server.exceptions as exceptions
 import candig.server.datamodel.sequence_annotations as sequence_annotations
 import candig.server.datamodel.genotype_phenotype as g2p
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 # annotation keys
 TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'

--- a/candig/server/datamodel/genotype_phenotype_featureset.py
+++ b/candig/server/datamodel/genotype_phenotype_featureset.py
@@ -15,7 +15,7 @@ import candig.server.exceptions as exceptions
 import candig.server.datamodel.sequence_annotations as sequence_annotations
 import candig.server.datamodel.genotype_phenotype as g2p
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 # annotation keys
 TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type'

--- a/candig/server/datamodel/ontologies.py
+++ b/candig/server/datamodel/ontologies.py
@@ -11,7 +11,7 @@ import os.path
 import candig.server.exceptions as exceptions
 import candig.server.datamodel.obo_parser as obo_parser
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 SEQUENCE_ONTOLOGY_PREFIX = "SO"

--- a/candig/server/datamodel/ontologies.py
+++ b/candig/server/datamodel/ontologies.py
@@ -11,7 +11,7 @@ import os.path
 import candig.server.exceptions as exceptions
 import candig.server.datamodel.obo_parser as obo_parser
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 SEQUENCE_ONTOLOGY_PREFIX = "SO"

--- a/candig/server/datamodel/peers.py
+++ b/candig/server/datamodel/peers.py
@@ -11,7 +11,7 @@ import urlparse
 
 import candig.server.exceptions as exceptions
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 def isUrl(urlString):

--- a/candig/server/datamodel/peers.py
+++ b/candig/server/datamodel/peers.py
@@ -11,7 +11,7 @@ import urlparse
 
 import candig.server.exceptions as exceptions
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 def isUrl(urlString):

--- a/candig/server/datamodel/pipeline_metadata.py
+++ b/candig/server/datamodel/pipeline_metadata.py
@@ -13,7 +13,7 @@ import datetime
 import candig.server.datamodel as datamodel
 import candig.server.exceptions as exceptions
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 class Extraction(datamodel.DatamodelObject):

--- a/candig/server/datamodel/pipeline_metadata.py
+++ b/candig/server/datamodel/pipeline_metadata.py
@@ -13,7 +13,7 @@ import datetime
 import candig.server.datamodel as datamodel
 import candig.server.exceptions as exceptions
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 class Extraction(datamodel.DatamodelObject):

--- a/candig/server/datamodel/reads.py
+++ b/candig/server/datamodel/reads.py
@@ -17,8 +17,8 @@ import candig.server.datamodel as datamodel
 import candig.server.datamodel.references as references
 import candig.server.exceptions as exceptions
 
-import ga4gh.schemas.pb as pb
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.pb as pb
+import candig.schemas.protocol as protocol
 
 
 def parseMalformedBamHeader(headerDict):

--- a/candig/server/datamodel/reads.py
+++ b/candig/server/datamodel/reads.py
@@ -17,8 +17,8 @@ import candig.server.datamodel as datamodel
 import candig.server.datamodel.references as references
 import candig.server.exceptions as exceptions
 
-import candig.schemas.pb as pb
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.pb as pb
+import ga4gh.schemas.protocol as protocol
 
 
 def parseMalformedBamHeader(headerDict):

--- a/candig/server/datamodel/references.py
+++ b/candig/server/datamodel/references.py
@@ -15,8 +15,8 @@ import pysam
 import candig.server.datamodel as datamodel
 import candig.server.exceptions as exceptions
 
-import ga4gh.schemas.pb as pb
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.pb as pb
+import candig.schemas.protocol as protocol
 
 
 DEFAULT_REFERENCESET_NAME = "Default"

--- a/candig/server/datamodel/references.py
+++ b/candig/server/datamodel/references.py
@@ -15,8 +15,8 @@ import pysam
 import candig.server.datamodel as datamodel
 import candig.server.exceptions as exceptions
 
-import candig.schemas.pb as pb
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.pb as pb
+import ga4gh.schemas.protocol as protocol
 
 
 DEFAULT_REFERENCESET_NAME = "Default"

--- a/candig/server/datamodel/rna_quantification.py
+++ b/candig/server/datamodel/rna_quantification.py
@@ -10,7 +10,7 @@ import candig.server.datamodel as datamodel
 import candig.server.exceptions as exceptions
 import candig.server.sqlite_backend as sqlite_backend
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 """

--- a/candig/server/datamodel/rna_quantification.py
+++ b/candig/server/datamodel/rna_quantification.py
@@ -10,7 +10,7 @@ import candig.server.datamodel as datamodel
 import candig.server.exceptions as exceptions
 import candig.server.sqlite_backend as sqlite_backend
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 """

--- a/candig/server/datamodel/sequence_annotations.py
+++ b/candig/server/datamodel/sequence_annotations.py
@@ -13,8 +13,8 @@ import candig.server.datamodel as datamodel
 import candig.server.sqlite_backend as sqlite_backend
 import candig.server.exceptions as exceptions
 
-import ga4gh.schemas.pb as pb
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.pb as pb
+import candig.schemas.protocol as protocol
 
 # Note to self: There's the Feature ID as understood in a GFF3 file,
 # the Feature ID that is its server-assigned compoundId, and the

--- a/candig/server/datamodel/sequence_annotations.py
+++ b/candig/server/datamodel/sequence_annotations.py
@@ -13,8 +13,8 @@ import candig.server.datamodel as datamodel
 import candig.server.sqlite_backend as sqlite_backend
 import candig.server.exceptions as exceptions
 
-import candig.schemas.pb as pb
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.pb as pb
+import ga4gh.schemas.protocol as protocol
 
 # Note to self: There's the Feature ID as understood in a GFF3 file,
 # the Feature ID that is its server-assigned compoundId, and the

--- a/candig/server/datamodel/variants.py
+++ b/candig/server/datamodel/variants.py
@@ -19,8 +19,8 @@ import pysam
 import candig.server.exceptions as exceptions
 import candig.server.datamodel as datamodel
 
-import ga4gh.schemas.pb as pb
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.pb as pb
+import candig.schemas.protocol as protocol
 
 
 ANNOTATIONS_VEP_V82 = "VEP_v82"

--- a/candig/server/datamodel/variants.py
+++ b/candig/server/datamodel/variants.py
@@ -19,8 +19,8 @@ import pysam
 import candig.server.exceptions as exceptions
 import candig.server.datamodel as datamodel
 
-import candig.schemas.pb as pb
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.pb as pb
+import ga4gh.schemas.protocol as protocol
 
 
 ANNOTATIONS_VEP_V82 = "VEP_v82"

--- a/candig/server/datarepo.py
+++ b/candig/server/datarepo.py
@@ -27,7 +27,7 @@ import candig.server.repo.models as models
 import candig.server.datamodel.clinical_metadata as clinical_metadata
 import candig.server.datamodel.pipeline_metadata as pipeline_metadata
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 MODE_READ = 'r'
 MODE_WRITE = 'w'

--- a/candig/server/datarepo.py
+++ b/candig/server/datarepo.py
@@ -27,7 +27,7 @@ import candig.server.repo.models as models
 import candig.server.datamodel.clinical_metadata as clinical_metadata
 import candig.server.datamodel.pipeline_metadata as pipeline_metadata
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 MODE_READ = 'r'
 MODE_WRITE = 'w'

--- a/candig/server/exceptions.py
+++ b/candig/server/exceptions.py
@@ -11,7 +11,7 @@ import zlib
 import inspect
 import json
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 def getExceptionClass(errorCode):

--- a/candig/server/exceptions.py
+++ b/candig/server/exceptions.py
@@ -11,7 +11,7 @@ import zlib
 import inspect
 import json
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 def getExceptionClass(errorCode):

--- a/candig/server/frontend.py
+++ b/candig/server/frontend.py
@@ -38,7 +38,7 @@ import candig.server.datarepo as datarepo
 import candig.server.auth as auth
 import candig.server.network as network
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 import base64
 import pandas as pd

--- a/candig/server/frontend.py
+++ b/candig/server/frontend.py
@@ -38,7 +38,7 @@ import candig.server.datarepo as datarepo
 import candig.server.auth as auth
 import candig.server.network as network
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 import base64
 import pandas as pd

--- a/candig/server/response_builder.py
+++ b/candig/server/response_builder.py
@@ -5,8 +5,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import candig.schemas.pb as pb
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.pb as pb
+import ga4gh.schemas.protocol as protocol
 
 
 class SearchResponseBuilder(object):

--- a/candig/server/response_builder.py
+++ b/candig/server/response_builder.py
@@ -5,8 +5,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import ga4gh.schemas.pb as pb
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.pb as pb
+import candig.schemas.protocol as protocol
 
 
 class SearchResponseBuilder(object):

--- a/constraints.txt
+++ b/constraints.txt
@@ -21,5 +21,6 @@
 # When making a release, these constraints are commented out so that
 # the pinned packages in requirements.txt are used instead.
 #
+#git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
 git+git://github.com/CanDIG/candig-schemas.git@test_update_protocol_190610#egg=candig_schemas
 git+git://github.com/CanDIG/candig-client.git@develop#egg=candig_client

--- a/constraints.txt
+++ b/constraints.txt
@@ -22,5 +22,5 @@
 # the pinned packages in requirements.txt are used instead.
 #
 #git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
-git+git://github.com/CanDIG/candig-schemas.git@bugfix_190610_change_namespace#egg=ga4gh_schemas
+git+git://github.com/CanDIG/candig-schemas.git@bugfix_190610_change_namespace#egg=candig_schemas
 git+git://github.com/CanDIG/candig-client.git@develop#egg=candig_client

--- a/constraints.txt
+++ b/constraints.txt
@@ -21,6 +21,5 @@
 # When making a release, these constraints are commented out so that
 # the pinned packages in requirements.txt are used instead.
 #
-#git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
 git+git://github.com/CanDIG/candig-schemas.git@test_update_protocol_190610#egg=candig_schemas
 git+git://github.com/CanDIG/candig-client.git@develop#egg=candig_client

--- a/constraints.txt
+++ b/constraints.txt
@@ -23,4 +23,4 @@
 #
 #git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
 git+git://github.com/CanDIG/candig-schemas.git@develop#egg=candig_schemas
-git+git://github.com/CanDIG/candig-client.git@develop#egg=candig_client
+git+git://github.com/CanDIG/candig-client.git@test_update_protocol_190610#egg=candig_client

--- a/constraints.txt
+++ b/constraints.txt
@@ -23,4 +23,4 @@
 #
 #git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
 git+git://github.com/CanDIG/candig-schemas.git@bugfix_190610_change_namespace#egg=ga4gh_schemas
-git+git://github.com/CanDIG/candig-client.git@v0.7.0#egg=ga4gh_client
+git+git://github.com/CanDIG/candig-client.git@v0.8.0#egg=candig_client

--- a/constraints.txt
+++ b/constraints.txt
@@ -22,5 +22,5 @@
 # the pinned packages in requirements.txt are used instead.
 #
 #git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
-git+git://github.com/CanDIG/candig-schemas.git@bugfix_190610_change_namespace#egg=candig_schemas
+git+git://github.com/CanDIG/candig-schemas.git@develop#egg=candig_schemas
 git+git://github.com/CanDIG/candig-client.git@develop#egg=candig_client

--- a/constraints.txt
+++ b/constraints.txt
@@ -22,5 +22,5 @@
 # the pinned packages in requirements.txt are used instead.
 #
 #git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
-git+git://github.com/CanDIG/candig-schemas.git@bugfix_190523_update_proto_paths#egg=ga4gh_schemas
+git+git://github.com/CanDIG/candig-schemas.git@bugfix_190610_change_namespace#egg=ga4gh_schemas
 git+git://github.com/CanDIG/candig-client.git@v0.7.0#egg=ga4gh_client

--- a/constraints.txt
+++ b/constraints.txt
@@ -23,4 +23,4 @@
 #
 #git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
 git+git://github.com/CanDIG/candig-schemas.git@v0.8.0#egg=candig_schemas
-git+git://github.com/CanDIG/candig-client.git@authz#egg=ga4gh_client
+git+git://github.com/CanDIG/candig-client.git@develop#egg=candig_client

--- a/constraints.txt
+++ b/constraints.txt
@@ -22,5 +22,5 @@
 # the pinned packages in requirements.txt are used instead.
 #
 #git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
-git+git://github.com/CanDIG/candig-schemas.git@v0.7.1#egg=ga4gh_schemas
+git+git://github.com/CanDIG/candig-schemas.git@v0.8.0#egg=candig_schemas
 git+git://github.com/CanDIG/candig-client.git@authz#egg=ga4gh_client

--- a/constraints.txt
+++ b/constraints.txt
@@ -22,5 +22,5 @@
 # the pinned packages in requirements.txt are used instead.
 #
 #git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
-git+git://github.com/CanDIG/candig-schemas.git@develop#egg=ga4gh_schemas
+git+git://github.com/CanDIG/candig-schemas.git@v0.7.1#egg=ga4gh_schemas
 git+git://github.com/CanDIG/candig-client.git@authz#egg=ga4gh_client

--- a/constraints.txt
+++ b/constraints.txt
@@ -23,4 +23,4 @@
 #
 #git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
 git+git://github.com/CanDIG/candig-schemas.git@bugfix_190610_change_namespace#egg=ga4gh_schemas
-git+git://github.com/CanDIG/candig-client.git@v0.8.0#egg=candig_client
+git+git://github.com/CanDIG/candig-client.git@develop#egg=candig_client

--- a/constraints.txt
+++ b/constraints.txt
@@ -22,5 +22,5 @@
 # the pinned packages in requirements.txt are used instead.
 #
 #git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
-git+git://github.com/CanDIG/candig-schemas.git@test_update_protocol_190610#egg=candig_schemas
+#git+git://github.com/CanDIG/candig-schemas.git@develop#egg=candig_schemas
 git+git://github.com/CanDIG/candig-client.git@develop#egg=candig_client

--- a/constraints.txt
+++ b/constraints.txt
@@ -22,5 +22,5 @@
 # the pinned packages in requirements.txt are used instead.
 #
 #git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
-git+git://github.com/CanDIG/candig-schemas.git@develop#egg=candig_schemas
-git+git://github.com/CanDIG/candig-client.git@test_update_protocol_190610#egg=candig_client
+git+git://github.com/CanDIG/candig-schemas.git@test_update_protocol_190610#egg=candig_schemas
+git+git://github.com/CanDIG/candig-client.git@develop#egg=candig_client

--- a/constraints.txt
+++ b/constraints.txt
@@ -22,5 +22,5 @@
 # the pinned packages in requirements.txt are used instead.
 #
 #git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
-git+git://github.com/CanDIG/candig-schemas.git@v0.7.2#egg=candig_schemas
-git+git://github.com/CanDIG/candig-client.git@develop#egg=candig_client
+git+git://github.com/CanDIG/candig-schemas.git@bugfix_190523_update_proto_paths#egg=ga4gh_schemas
+git+git://github.com/CanDIG/candig-client.git@v0.7.0#egg=ga4gh_client

--- a/constraints.txt
+++ b/constraints.txt
@@ -22,5 +22,5 @@
 # the pinned packages in requirements.txt are used instead.
 #
 #git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
-git+git://github.com/CanDIG/candig-schemas.git@v0.8.0#egg=candig_schemas
+git+git://github.com/CanDIG/candig-schemas.git@v0.7.2#egg=candig_schemas
 git+git://github.com/CanDIG/candig-client.git@develop#egg=candig_client

--- a/constraints.txt.default
+++ b/constraints.txt.default
@@ -22,5 +22,5 @@
 # the pinned packages in requirements.txt are used instead.
 #
 #git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
-git+git://github.com/CanDIG/ga4gh-schemas.git@experiment#egg=ga4gh_schemas
+#git+git://github.com/CanDIG/ga4gh-schemas.git@experiment#egg=ga4gh_schemas
 git+git://github.com/CanDIG/ga4gh-client.git@experiment#egg=ga4gh_client

--- a/docs/demo.rst
+++ b/docs/demo.rst
@@ -185,7 +185,7 @@ performed above, we can use the following code:
 
     from __future__ import print_function
 
-    from candig.client import client
+    from ga4gh.client import client
 
     httpClient = client.HttpClient("http://localhost:8000")
     # Get the datasets on the server.
@@ -393,7 +393,7 @@ client's libraries for use in your own programs:
 
 .. code-block:: python
 
-    >>> from candig.client import client
+    >>> from ga4gh.client import client
     >>> client.HttpClient
     <class 'ga4gh_client.client.HttpClient'>
 

--- a/docs/demo.rst
+++ b/docs/demo.rst
@@ -185,7 +185,7 @@ performed above, we can use the following code:
 
     from __future__ import print_function
 
-    from ga4gh.client import client
+    from candig.client import client
 
     httpClient = client.HttpClient("http://localhost:8000")
     # Get the datasets on the server.
@@ -393,7 +393,7 @@ client's libraries for use in your own programs:
 
 .. code-block:: python
 
-    >>> from ga4gh.client import client
+    >>> from candig.client import client
     >>> client.HttpClient
     <class 'ga4gh_client.client.HttpClient'>
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@
 # the constraints file will point at the current master branch 
 # of the respective module.
 ga4gh-common==0.0.7
-ga4gh-schemas
+candig-schemas
 ga4gh-client
 
 Werkzeug==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,8 @@
 # the constraints file will point at the current master branch 
 # of the respective module.
 ga4gh-common==0.0.7
-candig-schemas
-candig-client
+ga4gh-schemas
+ga4gh-client
 
 Werkzeug==0.14.1
 MarkupSafe==0.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@
 # the constraints file will point at the current master branch 
 # of the respective module.
 ga4gh-common==0.0.7
-candig-schemas
+candig-schemas==0.8.0
 candig-client
 
 Werkzeug==0.14.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,8 +13,8 @@
 # the constraints file will point at the current master branch 
 # of the respective module.
 ga4gh-common==0.0.7
-ga4gh-schemas
-ga4gh-client
+candig-schemas
+candig-client
 
 Werkzeug==0.14.1
 MarkupSafe==0.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@
 # of the respective module.
 ga4gh-common==0.0.7
 candig-schemas
-ga4gh-client
+candig-client
 
 Werkzeug==0.14.1
 MarkupSafe==0.23

--- a/scripts/demo_example.py
+++ b/scripts/demo_example.py
@@ -6,7 +6,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import candig.client.client as client
+import ga4gh.client.client as client
 
 
 def runDemo():

--- a/scripts/demo_example.py
+++ b/scripts/demo_example.py
@@ -6,7 +6,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import ga4gh.client.client as client
+import candig.client.client as client
 
 
 def runDemo():

--- a/scripts/server_benchmark.py
+++ b/scripts/server_benchmark.py
@@ -15,7 +15,7 @@ import guppy
 
 import glue
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 glue.ga4ghImportGlue()
 import candig.server.backend as backend  # noqa

--- a/scripts/server_benchmark.py
+++ b/scripts/server_benchmark.py
@@ -15,7 +15,7 @@ import guppy
 
 import glue
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 glue.ga4ghImportGlue()
 import candig.server.backend as backend  # noqa

--- a/tests/datadriven/__init__.py
+++ b/tests/datadriven/__init__.py
@@ -15,8 +15,8 @@ import array
 
 import google.protobuf.json_format as json_format
 
-import candig.schemas.pb as pb
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.pb as pb
+import ga4gh.schemas.protocol as protocol
 
 
 def _wrapTestMethod(method):

--- a/tests/datadriven/__init__.py
+++ b/tests/datadriven/__init__.py
@@ -15,8 +15,8 @@ import array
 
 import google.protobuf.json_format as json_format
 
-import ga4gh.schemas.pb as pb
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.pb as pb
+import candig.schemas.protocol as protocol
 
 
 def _wrapTestMethod(method):

--- a/tests/datadriven/test_genotype_phenotype.py
+++ b/tests/datadriven/test_genotype_phenotype.py
@@ -13,7 +13,7 @@ import candig.server.datamodel.datasets as datasets
 import tests.datadriven as datadriven
 import tests.paths as paths
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 def testG2P():

--- a/tests/datadriven/test_genotype_phenotype.py
+++ b/tests/datadriven/test_genotype_phenotype.py
@@ -13,7 +13,7 @@ import candig.server.datamodel.datasets as datasets
 import tests.datadriven as datadriven
 import tests.paths as paths
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 def testG2P():

--- a/tests/datadriven/test_ontologies.py
+++ b/tests/datadriven/test_ontologies.py
@@ -16,8 +16,8 @@ import candig.server.datamodel.ontologies as ontologies
 import tests.datadriven as datadriven
 import tests.paths as paths
 
-from candig.schemas.ga4gh.common_pb2 import OntologyTerm
-import candig.schemas.protocol as protocol
+from ga4gh.schemas.ga4gh.common_pb2 import OntologyTerm
+import ga4gh.schemas.protocol as protocol
 
 
 def testReferenceSets():

--- a/tests/datadriven/test_ontologies.py
+++ b/tests/datadriven/test_ontologies.py
@@ -16,7 +16,7 @@ import candig.server.datamodel.ontologies as ontologies
 import tests.datadriven as datadriven
 import tests.paths as paths
 
-from candig.schemas.ga4gh.common_pb2 import OntologyTerm
+from candig.schemas.candig.common_pb2 import OntologyTerm
 import candig.schemas.protocol as protocol
 
 

--- a/tests/datadriven/test_ontologies.py
+++ b/tests/datadriven/test_ontologies.py
@@ -16,8 +16,8 @@ import candig.server.datamodel.ontologies as ontologies
 import tests.datadriven as datadriven
 import tests.paths as paths
 
-from ga4gh.schemas.ga4gh.common_pb2 import OntologyTerm
-import ga4gh.schemas.protocol as protocol
+from candig.schemas.ga4gh.common_pb2 import OntologyTerm
+import candig.schemas.protocol as protocol
 
 
 def testReferenceSets():

--- a/tests/datadriven/test_reads.py
+++ b/tests/datadriven/test_reads.py
@@ -18,7 +18,7 @@ import tests.datadriven as datadriven
 import tests.paths as paths
 
 import ga4gh.common.utils as utils
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 import pysam
 

--- a/tests/datadriven/test_reads.py
+++ b/tests/datadriven/test_reads.py
@@ -18,7 +18,7 @@ import tests.datadriven as datadriven
 import tests.paths as paths
 
 import ga4gh.common.utils as utils
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 import pysam
 

--- a/tests/datadriven/test_references.py
+++ b/tests/datadriven/test_references.py
@@ -20,7 +20,7 @@ import candig.server.exceptions as exceptions
 import tests.datadriven as datadriven
 import tests.paths as paths
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 def testReferenceSets():

--- a/tests/datadriven/test_references.py
+++ b/tests/datadriven/test_references.py
@@ -20,7 +20,7 @@ import candig.server.exceptions as exceptions
 import tests.datadriven as datadriven
 import tests.paths as paths
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 def testReferenceSets():

--- a/tests/datadriven/test_rna_quantification.py
+++ b/tests/datadriven/test_rna_quantification.py
@@ -18,7 +18,7 @@ import candig.server.datamodel.rna_quantification as rna_quantification
 import tests.datadriven as datadriven
 import tests.paths as paths
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 _datasetName = "ds"

--- a/tests/datadriven/test_rna_quantification.py
+++ b/tests/datadriven/test_rna_quantification.py
@@ -18,7 +18,7 @@ import candig.server.datamodel.rna_quantification as rna_quantification
 import tests.datadriven as datadriven
 import tests.paths as paths
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 _datasetName = "ds"

--- a/tests/datadriven/test_sequence_annotations.py
+++ b/tests/datadriven/test_sequence_annotations.py
@@ -13,7 +13,7 @@ import candig.server.datamodel.sequence_annotations as sequence_annotations
 import tests.datadriven as datadriven
 import tests.paths as paths
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 _datasetName = "ds"
 

--- a/tests/datadriven/test_sequence_annotations.py
+++ b/tests/datadriven/test_sequence_annotations.py
@@ -13,7 +13,7 @@ import candig.server.datamodel.sequence_annotations as sequence_annotations
 import tests.datadriven as datadriven
 import tests.paths as paths
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 _datasetName = "ds"
 

--- a/tests/datadriven/test_variant_annotations.py
+++ b/tests/datadriven/test_variant_annotations.py
@@ -18,7 +18,7 @@ import candig.server.datamodel.ontologies as ontologies
 import tests.datadriven as datadriven
 import tests.paths as paths
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 def testVariantAnnotationSets():

--- a/tests/datadriven/test_variant_annotations.py
+++ b/tests/datadriven/test_variant_annotations.py
@@ -18,7 +18,7 @@ import candig.server.datamodel.ontologies as ontologies
 import tests.datadriven as datadriven
 import tests.paths as paths
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 def testVariantAnnotationSets():

--- a/tests/datadriven/test_variants.py
+++ b/tests/datadriven/test_variants.py
@@ -20,7 +20,7 @@ import tests.datadriven as datadriven
 import tests.paths as paths
 
 import ga4gh.common.utils as utils
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 def testVariantSets():

--- a/tests/datadriven/test_variants.py
+++ b/tests/datadriven/test_variants.py
@@ -20,7 +20,7 @@ import tests.datadriven as datadriven
 import tests.paths as paths
 
 import ga4gh.common.utils as utils
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 def testVariantSets():

--- a/tests/end_to_end/test_client_json.py
+++ b/tests/end_to_end/test_client_json.py
@@ -12,15 +12,15 @@ import json
 import unittest
 import freezegun
 
-import candig.client.client as client
+import ga4gh.client.client as client
 import candig.server.backend as backend
-import candig.client.cli as cli_client
+import ga4gh.client.cli as cli_client
 import candig.server.datarepo as datarepo
 import ga4gh.common.utils as utils
 import tests.paths as paths
 import server
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 def setUpModule():

--- a/tests/end_to_end/test_client_json.py
+++ b/tests/end_to_end/test_client_json.py
@@ -20,7 +20,7 @@ import ga4gh.common.utils as utils
 import tests.paths as paths
 import server
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 def setUpModule():

--- a/tests/end_to_end/test_client_json.py
+++ b/tests/end_to_end/test_client_json.py
@@ -12,9 +12,9 @@ import json
 import unittest
 import freezegun
 
-import ga4gh.client.client as client
+import candig.client.client as client
 import candig.server.backend as backend
-import ga4gh.client.cli as cli_client
+import candig.client.cli as cli_client
 import candig.server.datarepo as datarepo
 import ga4gh.common.utils as utils
 import tests.paths as paths

--- a/tests/end_to_end/test_g2p.py
+++ b/tests/end_to_end/test_g2p.py
@@ -9,7 +9,7 @@ import candig.server.datamodel as datamodel
 import candig.server.frontend as frontend
 import tests.paths as paths
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 class TestG2P(unittest.TestCase):

--- a/tests/end_to_end/test_g2p.py
+++ b/tests/end_to_end/test_g2p.py
@@ -9,7 +9,7 @@ import candig.server.datamodel as datamodel
 import candig.server.frontend as frontend
 import tests.paths as paths
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 class TestG2P(unittest.TestCase):

--- a/tests/end_to_end/test_repo_manager.py
+++ b/tests/end_to_end/test_repo_manager.py
@@ -14,7 +14,7 @@ import json
 import candig.server.cli.repomanager as cli_repomanager
 import tests.paths as paths
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 class RepoManagerEndToEndTest(unittest.TestCase):

--- a/tests/end_to_end/test_repo_manager.py
+++ b/tests/end_to_end/test_repo_manager.py
@@ -14,7 +14,7 @@ import json
 import candig.server.cli.repomanager as cli_repomanager
 import tests.paths as paths
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 class RepoManagerEndToEndTest(unittest.TestCase):

--- a/tests/end_to_end/test_sequence_annotations.py
+++ b/tests/end_to_end/test_sequence_annotations.py
@@ -12,7 +12,7 @@ import json
 import candig.server.frontend as frontend
 import tests.paths as paths
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 class TestSequenceAnnotations(unittest.TestCase):

--- a/tests/end_to_end/test_sequence_annotations.py
+++ b/tests/end_to_end/test_sequence_annotations.py
@@ -12,7 +12,7 @@ import json
 import candig.server.frontend as frontend
 import tests.paths as paths
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 class TestSequenceAnnotations(unittest.TestCase):

--- a/tests/unit/test_auth0.py
+++ b/tests/unit/test_auth0.py
@@ -13,7 +13,7 @@ import candig.server.frontend as frontend
 import candig.server.exceptions as exceptions
 import candig.server.auth as auth
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 class TestAuth0(unittest.TestCase):

--- a/tests/unit/test_auth0.py
+++ b/tests/unit/test_auth0.py
@@ -13,7 +13,7 @@ import candig.server.frontend as frontend
 import candig.server.exceptions as exceptions
 import candig.server.auth as auth
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 class TestAuth0(unittest.TestCase):

--- a/tests/unit/test_bio_metadata.py
+++ b/tests/unit/test_bio_metadata.py
@@ -11,7 +11,7 @@ import candig.server.datamodel.datasets as datasets
 import candig.server.exceptions as exceptions
 import candig.server.datamodel.bio_metadata as bioMetadata
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 class TestIndividuals(unittest.TestCase):

--- a/tests/unit/test_bio_metadata.py
+++ b/tests/unit/test_bio_metadata.py
@@ -11,7 +11,7 @@ import candig.server.datamodel.datasets as datasets
 import candig.server.exceptions as exceptions
 import candig.server.datamodel.bio_metadata as bioMetadata
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 class TestIndividuals(unittest.TestCase):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -11,7 +11,7 @@ import shlex
 import candig.server.cli.server as cli_server
 import candig.server.cli.repomanager as cli_repomanager
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 class TestServerArguments(unittest.TestCase):

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -11,7 +11,7 @@ import shlex
 import candig.server.cli.server as cli_server
 import candig.server.cli.repomanager as cli_repomanager
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 class TestServerArguments(unittest.TestCase):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -13,7 +13,7 @@ import candig.server.datarepo as datarepo
 
 import ga4gh.client.client as client
 import ga4gh.common.utils as utils
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 class DatamodelObjectWrapper(object):

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -11,7 +11,7 @@ import json
 import candig.server.backend as backend
 import candig.server.datarepo as datarepo
 
-import ga4gh.client.client as client
+import candig.client.client as client
 import ga4gh.common.utils as utils
 import candig.schemas.protocol as protocol
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -11,9 +11,9 @@ import json
 import candig.server.backend as backend
 import candig.server.datarepo as datarepo
 
-import candig.client.client as client
+import ga4gh.client.client as client
 import ga4gh.common.utils as utils
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 class DatamodelObjectWrapper(object):

--- a/tests/unit/test_clinical_metadata.py
+++ b/tests/unit/test_clinical_metadata.py
@@ -11,7 +11,7 @@ import candig.server.datamodel.datasets as datasets
 import candig.server.exceptions as exceptions
 import candig.server.datamodel.clinical_metadata as clinMetadata
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 class TestPatients(unittest.TestCase):

--- a/tests/unit/test_clinical_metadata.py
+++ b/tests/unit/test_clinical_metadata.py
@@ -11,7 +11,7 @@ import candig.server.datamodel.datasets as datasets
 import candig.server.exceptions as exceptions
 import candig.server.datamodel.clinical_metadata as clinMetadata
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 class TestPatients(unittest.TestCase):

--- a/tests/unit/test_data_interface.py
+++ b/tests/unit/test_data_interface.py
@@ -11,7 +11,7 @@ import candig.server.datarepo as datarepo
 import candig.server.backend as backend
 import tests.paths as paths
 
-import candig.client.client as client
+import ga4gh.client.client as client
 import ga4gh.common.utils as utils
 
 

--- a/tests/unit/test_data_interface.py
+++ b/tests/unit/test_data_interface.py
@@ -11,7 +11,7 @@ import candig.server.datarepo as datarepo
 import candig.server.backend as backend
 import tests.paths as paths
 
-import ga4gh.client.client as client
+import candig.client.client as client
 import ga4gh.common.utils as utils
 
 

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -12,7 +12,7 @@ import inspect
 import candig.server.exceptions as exceptions
 import candig.server.frontend as frontend
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 class TestExceptionHandler(unittest.TestCase):

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -12,7 +12,7 @@ import inspect
 import candig.server.exceptions as exceptions
 import candig.server.frontend as frontend
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 class TestExceptionHandler(unittest.TestCase):

--- a/tests/unit/test_faultydata.py
+++ b/tests/unit/test_faultydata.py
@@ -12,7 +12,7 @@ import candig.server.datamodel.datasets as datasets
 import candig.server.datamodel.variants as variants
 import candig.server.exceptions as exceptions
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 class FaultyVariantDataTest(unittest.TestCase):

--- a/tests/unit/test_faultydata.py
+++ b/tests/unit/test_faultydata.py
@@ -88,7 +88,7 @@ class TestDuplicateCallSetId(FaultyVariantDataTest):
     """
     localIds = ["duplicated_sampleid"]
 
-    @unittest.skipIf(protocol.version.startswith("0.6"), "")
+    @unittest.skip("There is no need to check protocol version here. The test gets skipped at all time.")
     def testInstantiation(self):
         for localId in self.localIds:
             path = self.getFullPath(localId)

--- a/tests/unit/test_faultydata.py
+++ b/tests/unit/test_faultydata.py
@@ -12,7 +12,7 @@ import candig.server.datamodel.datasets as datasets
 import candig.server.datamodel.variants as variants
 import candig.server.exceptions as exceptions
 
-import candig.schemas.protocol as protocol
+# import candig.schemas.protocol as protocol
 
 
 class FaultyVariantDataTest(unittest.TestCase):

--- a/tests/unit/test_faultydata.py
+++ b/tests/unit/test_faultydata.py
@@ -12,7 +12,7 @@ import candig.server.datamodel.datasets as datasets
 import candig.server.datamodel.variants as variants
 import candig.server.exceptions as exceptions
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 class FaultyVariantDataTest(unittest.TestCase):

--- a/tests/unit/test_pipeline_metadata.py
+++ b/tests/unit/test_pipeline_metadata.py
@@ -11,7 +11,7 @@ import candig.server.datamodel.datasets as datasets
 import candig.server.exceptions as exceptions
 import candig.server.datamodel.pipeline_metadata as pipeMetadata
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 class TestExtractions(unittest.TestCase):

--- a/tests/unit/test_pipeline_metadata.py
+++ b/tests/unit/test_pipeline_metadata.py
@@ -11,7 +11,7 @@ import candig.server.datamodel.datasets as datasets
 import candig.server.exceptions as exceptions
 import candig.server.datamodel.pipeline_metadata as pipeMetadata
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 class TestExtractions(unittest.TestCase):

--- a/tests/unit/test_protocol_errors.py
+++ b/tests/unit/test_protocol_errors.py
@@ -10,7 +10,7 @@ import unittest
 import candig.server.frontend as frontend
 import candig.server.exceptions as exceptions
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 class TestFrontendErrors(unittest.TestCase):

--- a/tests/unit/test_protocol_errors.py
+++ b/tests/unit/test_protocol_errors.py
@@ -10,7 +10,7 @@ import unittest
 import candig.server.frontend as frontend
 import candig.server.exceptions as exceptions
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 class TestFrontendErrors(unittest.TestCase):

--- a/tests/unit/test_reads.py
+++ b/tests/unit/test_reads.py
@@ -10,7 +10,7 @@ import unittest
 
 import candig.server.datamodel.reads as reads
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 class TestParseMalformedBamHeader(unittest.TestCase):

--- a/tests/unit/test_reads.py
+++ b/tests/unit/test_reads.py
@@ -10,7 +10,7 @@ import unittest
 
 import candig.server.datamodel.reads as reads
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 class TestParseMalformedBamHeader(unittest.TestCase):

--- a/tests/unit/test_response_generators.py
+++ b/tests/unit/test_response_generators.py
@@ -14,7 +14,7 @@ import candig.server.datamodel.variants as variants
 import candig.server.exceptions as exceptions
 import candig.server.datarepo as datarepo
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 def generateVariant():

--- a/tests/unit/test_response_generators.py
+++ b/tests/unit/test_response_generators.py
@@ -14,7 +14,7 @@ import candig.server.datamodel.variants as variants
 import candig.server.exceptions as exceptions
 import candig.server.datarepo as datarepo
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 def generateVariant():

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import unittest
 
 import candig.server.response_builder as response_builder
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 def getValueListName(cls):

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import unittest
 
 import candig.server.response_builder as response_builder
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 def getValueListName(cls):

--- a/tests/unit/test_simulated_stack.py
+++ b/tests/unit/test_simulated_stack.py
@@ -19,7 +19,7 @@ import candig.server.datamodel.sequence_annotations as sequence_annotations
 import candig.server.datamodel.continuous as continuous
 import candig.server.frontend as frontend
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 def round_float32(x_double):

--- a/tests/unit/test_simulated_stack.py
+++ b/tests/unit/test_simulated_stack.py
@@ -19,7 +19,7 @@ import candig.server.datamodel.sequence_annotations as sequence_annotations
 import candig.server.datamodel.continuous as continuous
 import candig.server.frontend as frontend
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 def round_float32(x_double):

--- a/tests/unit/test_variant_annotations.py
+++ b/tests/unit/test_variant_annotations.py
@@ -15,7 +15,7 @@ import candig.server.datamodel.datasets as datasets
 
 import tests.paths as paths
 
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 
 
 class TestHtslibVariantAnnotationSet(unittest.TestCase):

--- a/tests/unit/test_variant_annotations.py
+++ b/tests/unit/test_variant_annotations.py
@@ -15,7 +15,7 @@ import candig.server.datamodel.datasets as datasets
 
 import tests.paths as paths
 
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 
 
 class TestHtslibVariantAnnotationSet(unittest.TestCase):

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -12,7 +12,7 @@ import tests.paths as paths
 
 import candig.server.datamodel as datamodel
 import candig.server.frontend as frontend
-import ga4gh.schemas.protocol as protocol
+import candig.schemas.protocol as protocol
 import candig.server.exceptions as exceptions
 
 import json

--- a/tests/unit/test_views.py
+++ b/tests/unit/test_views.py
@@ -12,7 +12,7 @@ import tests.paths as paths
 
 import candig.server.datamodel as datamodel
 import candig.server.frontend as frontend
-import candig.schemas.protocol as protocol
+import ga4gh.schemas.protocol as protocol
 import candig.server.exceptions as exceptions
 
 import json


### PR DESCRIPTION
This PR mainly introduces the new namespace/package name of the candig-schemas and candig-client packages.

This PR will replace https://github.com/CanDIG/candig-server/pull/149 and https://github.com/CanDIG/candig-server/pull/150. Those two PRs will be closed without merging.

https://github.com/CanDIG/candig-server/pull/149 ran into the failing test problem. After some investigation, it was found that the protocol version was hardcoded into one of our failing tests. That test is now `skipped` at all time, and in my opinion, should eventually be removed. But removing unused code is outside of the scope of this PR.

**Note: I will be doing the merge. This particular PR should be using the squash and commit because there's too many meaningless commits to be preserved in the commits history.**