### PR TITLE
Refactor 190612 remove client from requirements

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -23,4 +23,4 @@
 #
 #git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
 #git+git://github.com/CanDIG/candig-schemas.git@develop#egg=candig_schemas
-git+git://github.com/CanDIG/candig-client.git@develop#egg=candig_client
+#git+git://github.com/CanDIG/candig-client.git@develop#egg=candig_client

--- a/constraints.txt.default
+++ b/constraints.txt.default
@@ -23,4 +23,4 @@
 #
 #git+git://github.com/ga4gh/ga4gh-common.git@master#egg=ga4gh_common
 #git+git://github.com/CanDIG/ga4gh-schemas.git@experiment#egg=ga4gh_schemas
-git+git://github.com/CanDIG/ga4gh-client.git@experiment#egg=ga4gh_client
+#git+git://github.com/CanDIG/ga4gh-client.git@experiment#egg=ga4gh_client

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -34,5 +34,8 @@ pyaml==15.03.1
 cherrypy==3.2.4
 yubico-client==1.9.1
 
+# For client-related test suite
+git+git://github.com/CanDIG/candig-client.git@v0.9.0
+
 # For ingesting various metadata
-git+git://github.com/CanDIG/candig-ingest.git@v1.1.1
+git+git://github.com/CanDIG/candig-ingest.git@v1.2.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -38,4 +38,4 @@ yubico-client==1.9.1
 git+git://github.com/CanDIG/candig-client.git@v0.9.0
 
 # For ingesting various metadata
-git+git://github.com/CanDIG/candig-ingest.git@v1.2.0
+candig-ingest==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,6 @@
 # of the respective module.
 ga4gh-common==0.0.7
 candig-schemas==0.8.0
-candig-client
 
 Werkzeug==0.14.1
 MarkupSafe==0.23


### PR DESCRIPTION
This PR introduces:

- The removal of `candig-client` from `requirements.txt`, instead, it is specified in the `dev-requirements.txt`, as the server itself does not utilize the client in any ways, only the test suite does. Even that, most, if not all of the client-related test-suite has been commented out/removed.

- The Pypi distribution of candig-ingest is used instead of the github link

- The github source URLs in constraints.txt have been commented out as the git source/package in either requirements.txt or dev-requirements will be used instead