### PR TITLE
handle the exception when files get removed after being ingested

### DIFF
--- a/candig/server/frontend.py
+++ b/candig/server/frontend.py
@@ -836,7 +836,12 @@ def handleException(exception):
         with app.test_request_context():
             app.log_exception(exception)
         serverException = exceptions.getServerError(exception)
-    error = serverException.toProtocolElement()
+    try:
+        error = serverException.toProtocolElement()
+    except AttributeError as e:
+        serverException = exceptions.NotFoundException(e)
+        error = serverException.toProtocolElement()
+
     # If the exception is being viewed by a web browser, we can render a nicer
     # view.
     if flask.request and 'Accept' in flask.request.headers and \


### PR DESCRIPTION
This PR resolves

- The unhandled exception when the files get removed after they have been ingested. This will affect the file-based API endpoints, such as variants.
- It may be up for future improvement, in particular if `NotFoundException` is the best exception class to use in this scenario.