### PR TITLE
restructure server info

### DIFF
--- a/candig/server/templates/index.html
+++ b/candig/server/templates/index.html
@@ -35,14 +35,18 @@
                 <tr>
                     <th>Method</th>
                     <th>Path</th>
+                    <th>Response</th>
+                    <th>Request Body</th>
                 </tr>
-                {% for url in info.getUrls() %}
                 <tr>
-                    <td>{{ url[0] }}</td>
-                    <td>{{ url[1] }}</td>
+                    <td>POST</td>
+                    <td>/token</td>
+                    <td>An access token</td>
+                    <td>{"username": "your_username", "password": "your_password"}</td>
                 </tr>
-                {% endfor %}
             </table>
+
+            For information on data-related endpoints, see <a href="/api_info">API Info Page</a>
         </div>
         <div>
             <h3>Uptime</h3>
@@ -65,32 +69,6 @@
         </div>
         <div>
             <h3>Data</h3>
-
-            <h4>ReferenceSets</h4>
-            <table class="table table-striped">
-                <tr>
-                    <th>Name</th>
-                    <th>Id</th>
-                    <th>Reference Name</th>
-                    <th>Reference Id</th>
-                </tr>
-                {% for referenceSet in info.getReferenceSets() %}
-                <tr>
-                    <td>{{ referenceSet.getLocalId() }}</td>
-                    <td>{{ referenceSet.getId() }}</td>
-                    <td></td>
-                    <td></td>
-                </tr>
-                {% for reference in referenceSet.getReferences() %}
-                <tr>
-                    <td></td>
-                    <td></td>
-                    <td>{{ reference.getLocalId() }}</td>
-                    <td>{{ reference.getId() }}</td>
-                </tr>
-                {% endfor %}
-                {% endfor %}
-            </table>
 
             {% for dataset in info.getDatasets() %}
             <h4>Dataset name: {{ dataset.getLocalId() }} id: {{ dataset.getId() }}</h4>
@@ -196,6 +174,33 @@
                     {% endfor %}
                 </table>
             {% endfor %}
+
+
+            <h4>ReferenceSets</h4>
+            <table class="table table-striped">
+                <tr>
+                    <th>Name</th>
+                    <th>Id</th>
+                    <th>Reference Name</th>
+                    <th>Reference Id</th>
+                </tr>
+                {% for referenceSet in info.getReferenceSets() %}
+                <tr>
+                    <td>{{ referenceSet.getLocalId() }}</td>
+                    <td>{{ referenceSet.getId() }}</td>
+                    <td></td>
+                    <td></td>
+                </tr>
+                {% for reference in referenceSet.getReferences() %}
+                <tr>
+                    <td></td>
+                    <td></td>
+                    <td>{{ reference.getLocalId() }}</td>
+                    <td>{{ reference.getId() }}</td>
+                </tr>
+                {% endfor %}
+                {% endfor %}
+            </table>
         </div>
     </div></body>
 </html>

--- a/candig/server/templates/initial_peers.txt
+++ b/candig/server/templates/initial_peers.txt
@@ -7,4 +7,4 @@
 # read this file to bootstrap the p2p network and will announce
 # to these peers.
 #
-http://1kgenomes.ga4gh.org
+# http://1kgenomes.ga4gh.org


### PR DESCRIPTION
This PR introduces

- Removal of most 'operations' with the exceptions of `/token`, info on rest of the endpoints get re-routed to /api_info
- Removal of a link in initial_peers.txt
- Relocation of the ReferenceSet to the end of the page, after datasets