### PR TITLE
fix repetitive features of a gene; added a CREATE INDEX command to th…

### DIFF
--- a/candig/server/backend.py
+++ b/candig/server/backend.py
@@ -2713,7 +2713,7 @@ class Backend(object):
 
         if request.gene != "":
             for featureset in dataset.getFeatureSets():
-                for feature in featureset.getFeatures(geneSymbol=request.gene):
+                for feature in featureset.getFeatures(geneSymbol=request.gene, featureTypes=["gene"]):
                     for variantset in processedVariantsets:
                         for variant in variantset.getVariants(
                                 referenceName=feature.reference_name.replace('chr', ''),

--- a/scripts/generate_gff3_db.py
+++ b/scripts/generate_gff3_db.py
@@ -116,6 +116,7 @@ class Gff32Db(object):
         dbcur.execute((
             "create INDEX idx1 "
             "on feature(start, end, reference_name)"))
+        dbcur.execute("CREATE INDEX name_type_index ON FEATURE (gene_name, type)")
         dbcur.execute("PRAGMA INDEX_LIST('feature')")
 
         dbcur.close()


### PR DESCRIPTION
…e script

Previously, a gene_search request would iterate through all the features returned by the /features/search, but we did not have a type filter in place, so there were repetitive ranges returned, this would lead to duplicated results.

A `CREATE INDEX` command was added to the script that converts gff3 file to a DB, this optimization is needed for our use case here.