### PR TITLE
update werkzeug to avoid security vulnerabilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@
 candig-common==1.0.0
 candig-schemas==1.0.0
 
-Werkzeug==0.14.1
+Werkzeug==0.15.5
 MarkupSafe==0.23
 itsdangerous==0.24
 six==1.10.0


### PR DESCRIPTION
This PR introduces

- The update of werkzeug. It is used as a dependency of flask, and the flask==1.0.2 we use accepts werkzeug >= 0.14.0, so there should not be backward incompatibilities.