### PR TITLE
1.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *~
 *.swp
 *.swo
-ga4gh-example-data*
+candig-example-data*
 ga4gh-downloaded-data*
 ga4gh-compliance-data*
 scripts/auth.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,66 +1,53 @@
-############################################################
-## Dockerfile to build the ga4gh server on mod_wsgi-express
-## Configurable to use a local dataset
-############################################################
-FROM ubuntu
+# Using multi stage to prevent keeping a second copy of the package in the image
+FROM centos:7.6.1810
+RUN yum -y install epel-release
+RUN yum -y install python36-pip.noarch \
+ git \
+ libffi-devel.x86_64 gcc-c++.x86_64 \
+ python36-devel.x86_64 openssl-devel \
+ libxml2-devel.x86_64 libxslt-devel.x86_64  libcurl-devel.x86_64 make gcc  \
+ && pip3 install --upgrade pip setuptools
 
-# Originally created by Steve Hershman GitHub @hershman
-# previously maintained by Alastair Firth, and Maciek Smuga-Otto of the
-# UCSC Genomics Institute
-MAINTAINER David Steinberg <david@resium.com>
+ENV SCHEMA_V=v1.0.0 INGEST_V=v1.3.0
 
-# Update the sources list
-RUN apt-get update  --fix-missing
-RUN apt-get upgrade --yes
+RUN  pip install \
+  git+https://github.com/CanDIG/candig-schemas.git@${SHEMA_V}#egg=candig_schemas  \
+  git+https://github.com/CanDIG/candig-ingest.git@${INGEST_V}#egg=candig_ingest \
+  gevent
 
-# Install packages
-RUN apt-get install -y tar git curl libcurl4-openssl-dev wget dialog \
-    net-tools build-essential python python-dev python-distribute \
-    python-pip zlib1g-dev apache2 libapache2-mod-wsgi libxslt1-dev \
-    libffi-dev libssl-dev
+COPY . /tmp/server
+RUN cd /tmp/server/ && pip install .
 
-# Enable wsgi module
-RUN a2enmod wsgi
+RUN mkdir /data
+WORKDIR /data
+RUN mkdir  mkdir candig-example-data \
+  && touch access_list.tsv
 
-# Create cache directories
-RUN mkdir /var/cache/apache2/python-egg-cache && \
-    chown www-data:www-data /var/cache/apache2/python-egg-cache/
+RUN curl -Lo /tmp/mock_data.json  https://github.com/CanDIG/candig-ingest/releases/download/${INGEST_V}/mock_data.json \
+ && ingest candig-example-data/registry.db mock_data /tmp/mock_data.json
 
-# build the GA4GH server
-RUN mkdir -p /srv/ga4gh/server
-WORKDIR /srv/ga4gh/server
 
-# Configure the python requirements
-# Do this as a separate step prior to the build so that changes
-# to the GA4GH Server codebase do not trigger a full rebuild of the
-# pip requirements.
-COPY requirements.txt /srv/ga4gh/server/
-COPY constraints.txt /srv/ga4gh/server/
-RUN pip install -r requirements.txt -c constraints.txt
+FROM centos:7.6.1810
+MAINTAINER P-O Quirion <pierre-olivier.quirion@calculquebec.ca>
+RUN yum -y install epel-release
+RUN yum -y install  \
+ gcc-c++.x86_64 \
+ python36.x86_64 openssl-devel \
+ && yum clean all \
+ && rm -rf /var/cache/yum
 
-# Install the code
-COPY . /srv/ga4gh/server/
-RUN pip install . -c constraints.txt
+# 0 is the irst stage
 
-# Write new apache config
-COPY deploy/001-ga4gh.conf /etc/apache2/sites-available/001-ga4gh.conf
+RUN mkdir /etc/candig && chmod 777 /etc/candig
 
-# Write application.wsgi
-COPY deploy/application.wsgi /srv/ga4gh/application.wsgi
-COPY deploy/config.py /srv/ga4gh/config.py
+RUN mkdir -p /opt/candig_server/
+# The ls forces a cash flush
 
-# Configure apache to serve GA4GH site
-WORKDIR /etc/apache2/sites-enabled
-RUN a2dissite 000-default
-RUN a2ensite 001-ga4gh
+COPY --from=0 /data /data
+COPY --from=0 /usr/local /usr/local
 
-# Open port 80 for HTTP
+WORKDIR /data
 EXPOSE 80
 
-# Prepare container for deployment
-# The directory that the user will land in when executing an interactive shell
-WORKDIR /srv/ga4gh/server
-RUN python scripts/prepare_compliance_data.py -o ../ga4gh-compliance-data
-
-# Default action: Bring up a webserver instance to run as a daemon
-CMD ["/usr/sbin/apache2ctl", "-D", "FOREGROUND"]
+ENTRYPOINT ["candig_server", "--host", "0.0.0.0", "--port", "80"]
+CMD  ["--workers", "1",  "--gunicorn", "-c", "NoAuth"]

--- a/candig/server/backend.py
+++ b/candig/server/backend.py
@@ -2713,7 +2713,7 @@ class Backend(object):
 
         if request.gene != "":
             for featureset in dataset.getFeatureSets():
-                for feature in featureset.getFeatures(geneSymbol=request.gene):
+                for feature in featureset.getFeatures(geneSymbol=request.gene, featureTypes=["gene"]):
                     for variantset in processedVariantsets:
                         for variant in variantset.getVariants(
                                 referenceName=feature.reference_name.replace('chr', ''),

--- a/candig/server/cli/server.py
+++ b/candig/server/cli/server.py
@@ -99,10 +99,11 @@ def server_main(args=None):
             'reload': not parsedArgs.dont_use_reloader,
         }
 
-        frontend.configure(configFile=parsedArgs.config_file, baseConfig="BaseConfig",
+        frontend.configure(configFile=parsedArgs.config_file, baseConfig=parsedArgs.config,
                            epsilon=parsedArgs.epsilon)
         app = StandaloneApplication(frontend.app, options)
         app.run()
+
     else:
 
         frontend.app.run(

--- a/candig/server/repo/models.py
+++ b/candig/server/repo/models.py
@@ -5,7 +5,7 @@ registry database.
 
 Partially auto-generated using pwiz.
 
-    python -m pwiz -e sqlite ga4gh-example-data/registry.db > models.py
+    python -m pwiz -e sqlite candig-example-data/registry.db > models.py
 
 For more on the peewee model API see:
 

--- a/candig/server/serverconfig.py
+++ b/candig/server/serverconfig.py
@@ -51,7 +51,7 @@ class DevelopmentConfig(BaseConfig):
     """
     Configuration used for development.
     """
-    DATA_SOURCE = "ga4gh-example-data/registry.db"
+    DATA_SOURCE = "candig-example-data/registry.db"
     # DATA_SOURCE = "1000genomes_partition/registry.db"
     DEBUG = True
     # INITIAL_PEERS =

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@
 candig-common==1.0.0
 candig-schemas==1.0.0
 
-Werkzeug==0.14.1
+Werkzeug==0.15.5
 MarkupSafe==0.23
 itsdangerous==0.24
 six==1.10.0

--- a/scripts/generate_gff3_db.py
+++ b/scripts/generate_gff3_db.py
@@ -116,6 +116,7 @@ class Gff32Db(object):
         dbcur.execute((
             "create INDEX idx1 "
             "on feature(start, end, reference_name)"))
+        dbcur.execute("CREATE INDEX name_type_index ON FEATURE (gene_name, type)")
         dbcur.execute("PRAGMA INDEX_LIST('feature')")
 
         dbcur.close()

--- a/scripts/server_benchmark.py
+++ b/scripts/server_benchmark.py
@@ -149,7 +149,7 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    registryDb = "ga4gh-example-data/registry.db"
+    registryDb = "candig-example-data/registry.db"
 
     if args.profile == 'heap':
         backendClass = HeapProfilerBackend


### PR DESCRIPTION
This PR introduces the update of 

- Updated Werkzeug
- Updated Dockerfile
- Updated command for creating index
- Updated search logic for gene_search

Additionally, a non-backward-compatible change was introduced in the default db folder of Development Config, which is now renamed to `candig-example-data`, developers will need to manually change the folder name. Local test servers that are not using the default DevelopmentConfig will not be effected. `DevelopmentConfig` should not be used for production config anyways, and should not affect them as such.