### PR TITLE
Bugfix 190911 improved exception message

### DIFF
--- a/candig/server/datarepo.py
+++ b/candig/server/datarepo.py
@@ -1498,8 +1498,9 @@ class SqlDataRepository(AbstractDataRepository):
                 attributes=json.dumps(readGroupSet.getAttributes()))
             for readGroup in readGroupSet.getReadGroups():
                 self.insertReadGroup(readGroup)
-        except Exception as e:
-            raise exceptions.RepoManagerException(e)
+        except peewee.IntegrityError as e:
+            raise exceptions.DuplicateNameException(readGroupSet.getLocalId(),
+                                                    readGroupSet.getParentContainer().getLocalId())
 
     def removeReferenceSet(self, referenceSet):
         """
@@ -1661,8 +1662,9 @@ class SqlDataRepository(AbstractDataRepository):
                 name=featureSet.getLocalId(),
                 dataurl=featureSet.getDataUrl(),
                 attributes=json.dumps(featureSet.getAttributes()))
-        except Exception as e:
-            raise exceptions.RepoManagerException(e)
+        except peewee.IntegrityError as e:
+            raise exceptions.DuplicateNameException(featureSet.getLocalId(),
+                                                    featureSet.getParentContainer().getLocalId())
 
     def _readFeatureSetTable(self):
         for featureSetRecord in models.Featureset.select():

--- a/candig/server/datarepo.py
+++ b/candig/server/datarepo.py
@@ -26,6 +26,8 @@ import candig.server.datamodel.pipeline_metadata as pipeline_metadata
 
 import candig.schemas.protocol as protocol
 
+import peewee
+
 MODE_READ = 'r'
 MODE_WRITE = 'w'
 
@@ -1623,8 +1625,9 @@ class SqlDataRepository(AbstractDataRepository):
                 patientId = variantSet.getPatientId(),
                 sampleId = variantSet.getSampleId(),
                 attributes=json.dumps(variantSet.getAttributes()))
-        except Exception as e:
-            raise exceptions.RepoManagerException(e)
+        except peewee.IntegrityError as e:
+            raise exceptions.DuplicateNameException(variantSet.getLocalId(),
+                                                    variantSet.getParentContainer().getLocalId())
         for callSet in variantSet.getCallSets():
             self.insertCallSet(callSet)
 


### PR DESCRIPTION
- use duplicateNameException to make the exception message clearer (instead of a generic `column id not unique`), currently only added for variantset, readgroupset and featureset; `insertReferenceSet` is already using duplicateNameException.