### PR TITLE
decode incoming request body

### DIFF
--- a/candig/server/cli/server.py
+++ b/candig/server/cli/server.py
@@ -55,6 +55,9 @@ def addServerOptions(parser):
         "--workers", "-w", default=1,
         help="number of gunicorn  worker.")
     parser.add_argument(
+        "--timeout", "-T", default=60,
+        help="Timeout limit of a request for gunicorn.")
+    parser.add_argument(
         "--worker_class", "-k", default='sync',
         help="The type of worker process to run. "
              "gevent or sync (default)")
@@ -93,6 +96,7 @@ def server_main(args=None):
         options = {
             'bind': '%s:%s' % (parsedArgs.host, parsedArgs.port),
             'workers': int(parsedArgs.workers),
+            'timeout': int(parsedArgs.timeout),
             'worker_class': parsedArgs.worker_class,
             'accesslog': '-',  # Puts the access log on stdout
             'errorlog': '-',  # Puts the error log on stdout

--- a/candig/server/frontend.py
+++ b/candig/server/frontend.py
@@ -779,7 +779,10 @@ def handleHttpPost(request, endpoint):
     if request.mimetype and request.mimetype not in protocol.MIMETYPES:
         raise exceptions.UnsupportedMediaTypeException()
     return_mimetype = chooseReturnMimetype(request)
-    request = request.get_data().decode()
+    try:
+        request = request.get_data().decode()
+    except AttributeError:
+        request = request.get_data()
     if request == '' or request is None:
         request = '{}'
     responseStr = federation(

--- a/candig/server/frontend.py
+++ b/candig/server/frontend.py
@@ -779,7 +779,7 @@ def handleHttpPost(request, endpoint):
     if request.mimetype and request.mimetype not in protocol.MIMETYPES:
         raise exceptions.UnsupportedMediaTypeException()
     return_mimetype = chooseReturnMimetype(request)
-    request = request.get_data()
+    request = request.get_data().decode()
     if request == '' or request is None:
         request = '{}'
     responseStr = federation(


### PR DESCRIPTION
- There's a procedure in place that converts empty body into empty dict, however, it only converts `''`, in order to convert `b''`, we need to decode it first
- Add a timeout config for gunicorn