### PR TITLE
Update travis config to include firefox test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,15 +78,13 @@ matrix:
       - cd "${TRAVIS_BUILD_DIR}"
       - pip install -r dev-requirements.txt
 #      - wget https://chromedriver.storage.googleapis.com/73.0.3683.68/chromedriver_linux64.zip
-      - wget https://github.com/mozilla/geckodriver/releases/download/v0.25.0/geckodriver-v0.25.0-linux64.tar.gz
+#      - wget https://github.com/mozilla/geckodriver/releases/download/v0.25.0/geckodriver-v0.25.0-linux64.tar.gz
 #      - unzip chromedriver_linux64.zip
-      - tar -xvf geckodriver-v0.25.0-linux64.tar.gz
-      - sudo mv geckodriver /usr/local/bin
-      - chmod +x /usr/local/bin/geckodriver
+#      - tar -xvf geckodriver-v0.25.0-linux64.tar.gz
 #      - chmod 777  chromedriver
 #      - sudo mv  chromedriver /usr/local/bin/.
-      - sudo apt-get install firefox chromium-chromedriver chromium-browser
-      - sudo rm  /usr/bin/google-chrome && sudo ln -s /usr/bin/chromium-browser  /usr/bin/google-chrome
+      -  sudo apt-get install firefox firefox-geckodriver chromium-chromedriver chromium-browser
+      -  sudo rm  /usr/bin/google-chrome && sudo ln -s /usr/bin/chromium-browser  /usr/bin/google-chrome
     before_script:
       - cd ${COMPOSE_DIR}
       - ./create_compose.sh -o "${TRAVIS_BUILD_DIR}/tests/integration/compose_config"

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ matrix:
     language: python
     python: 3.6
     addons:
+      firefox: latest
       hosts:
         - candig
         - candigauth

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,14 +79,14 @@ matrix:
       - cd "${TRAVIS_BUILD_DIR}"
       - pip install -r dev-requirements.txt
 #      - wget https://chromedriver.storage.googleapis.com/73.0.3683.68/chromedriver_linux64.zip
-#      - wget https://github.com/mozilla/geckodriver/releases/download/v0.25.0/geckodriver-v0.25.0-linux64.tar.gz
+      - wget https://github.com/mozilla/geckodriver/releases/download/v0.25.0/geckodriver-v0.25.0-linux64.tar.gz
 #      - unzip chromedriver_linux64.zip
-#      - tar -xvf geckodriver-v0.25.0-linux64.tar.gz
-#      - sudo mv geckodriver /usr/local/bin
-#      - chmod +x /usr/local/bin/geckodriver
+      - tar -xvf geckodriver-v0.25.0-linux64.tar.gz
+      - sudo mv geckodriver /usr/local/bin
+      - chmod +x /usr/local/bin/geckodriver
 #      - chmod 777  chromedriver
 #      - sudo mv  chromedriver /usr/local/bin/.
-      - sudo apt-get install firefox firefox-geckodriver chromium-chromedriver chromium-browser
+      - sudo apt-get install chromium-chromedriver chromium-browser
       - sudo rm  /usr/bin/google-chrome && sudo ln -s /usr/bin/chromium-browser  /usr/bin/google-chrome
     before_script:
       - cd ${COMPOSE_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,14 +78,14 @@ matrix:
       - cd "${TRAVIS_BUILD_DIR}"
       - pip install -r dev-requirements.txt
 #      - wget https://chromedriver.storage.googleapis.com/73.0.3683.68/chromedriver_linux64.zip
-#      - wget https://github.com/mozilla/geckodriver/releases/download/v0.25.0/geckodriver-v0.25.0-linux64.tar.gz
+      - wget https://github.com/mozilla/geckodriver/releases/download/v0.25.0/geckodriver-v0.25.0-linux64.tar.gz
 #      - unzip chromedriver_linux64.zip
-#      - tar -xvf geckodriver-v0.25.0-linux64.tar.gz
-#      - sudo mv geckodriver /usr/local/bin
-#      - chmod +x /usr/local/bin/geckodriver
+      - tar -xvf geckodriver-v0.25.0-linux64.tar.gz
+      - sudo mv geckodriver /usr/local/bin
+      - chmod +x /usr/local/bin/geckodriver
 #      - chmod 777  chromedriver
 #      - sudo mv  chromedriver /usr/local/bin/.
-      - sudo apt-get install firefox firefox-geckodriver chromium-chromedriver chromium-browser
+      - sudo apt-get install firefox chromium-chromedriver chromium-browser
       - sudo rm  /usr/bin/google-chrome && sudo ln -s /usr/bin/chromium-browser  /usr/bin/google-chrome
     before_script:
       - cd ${COMPOSE_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,13 +78,15 @@ matrix:
       - cd "${TRAVIS_BUILD_DIR}"
       - pip install -r dev-requirements.txt
 #      - wget https://chromedriver.storage.googleapis.com/73.0.3683.68/chromedriver_linux64.zip
-#      - wget https://github.com/mozilla/geckodriver/releases/download/v0.25.0/geckodriver-v0.25.0-linux64.tar.gz
+      - wget https://github.com/mozilla/geckodriver/releases/download/v0.25.0/geckodriver-v0.25.0-linux64.tar.gz
 #      - unzip chromedriver_linux64.zip
-#      - tar -xvf geckodriver-v0.25.0-linux64.tar.gz
+      - tar -xvf geckodriver-v0.25.0-linux64.tar.gz
+      - sudo mv geckodriver /usr/local/bin
+      - chmod +x /usr/local/bin/geckodriver
 #      - chmod 777  chromedriver
 #      - sudo mv  chromedriver /usr/local/bin/.
-      -  sudo apt-get install firefox firefox-geckodriver chromium-chromedriver chromium-browser
-      -  sudo rm  /usr/bin/google-chrome && sudo ln -s /usr/bin/chromium-browser  /usr/bin/google-chrome
+      - sudo apt-get install firefox chromium-chromedriver chromium-browser
+      - sudo rm  /usr/bin/google-chrome && sudo ln -s /usr/bin/chromium-browser  /usr/bin/google-chrome
     before_script:
       - cd ${COMPOSE_DIR}
       - ./create_compose.sh -o "${TRAVIS_BUILD_DIR}/tests/integration/compose_config"

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,14 +78,14 @@ matrix:
       - cd "${TRAVIS_BUILD_DIR}"
       - pip install -r dev-requirements.txt
 #      - wget https://chromedriver.storage.googleapis.com/73.0.3683.68/chromedriver_linux64.zip
-      - wget https://github.com/mozilla/geckodriver/releases/download/v0.25.0/geckodriver-v0.25.0-linux64.tar.gz
+#      - wget https://github.com/mozilla/geckodriver/releases/download/v0.25.0/geckodriver-v0.25.0-linux64.tar.gz
 #      - unzip chromedriver_linux64.zip
-      - tar -xvf geckodriver-v0.25.0-linux64.tar.gz
-      - sudo mv geckodriver /usr/local/bin
-      - chmod +x /usr/local/bin/geckodriver
+#      - tar -xvf geckodriver-v0.25.0-linux64.tar.gz
+#      - sudo mv geckodriver /usr/local/bin
+#      - chmod +x /usr/local/bin/geckodriver
 #      - chmod 777  chromedriver
 #      - sudo mv  chromedriver /usr/local/bin/.
-      - sudo apt-get install firefox chromium-chromedriver chromium-browser
+      - sudo apt-get install firefox firefox-geckodriver chromium-chromedriver chromium-browser
       - sudo rm  /usr/bin/google-chrome && sudo ln -s /usr/bin/chromium-browser  /usr/bin/google-chrome
     before_script:
       - cd ${COMPOSE_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,12 +78,14 @@ matrix:
       - cd "${TRAVIS_BUILD_DIR}"
       - pip install -r dev-requirements.txt
 #      - wget https://chromedriver.storage.googleapis.com/73.0.3683.68/chromedriver_linux64.zip
-#      - wget https://github.com/mozilla/geckodriver/releases/download/v0.25.0/geckodriver-v0.25.0-linux64.tar.gz
+      - wget https://github.com/mozilla/geckodriver/releases/download/v0.25.0/geckodriver-v0.25.0-linux64.tar.gz
 #      - unzip chromedriver_linux64.zip
-#      - tar -xvf geckodriver-v0.25.0-linux64.tar.gz
+      - tar -xvf geckodriver-v0.25.0-linux64.tar.gz
+      - sudo mv geckodriver /usr/local/bin
+      - chmod +x /usr/local/bin/geckodriver
 #      - chmod 777  chromedriver
 #      - sudo mv  chromedriver /usr/local/bin/.
-      -  sudo apt-get install firefox firefox-geckodriver chromium-chromedriver chromium-browser
+      - sudo apt-get install firefox chromium-chromedriver chromium-browser
       -  sudo rm  /usr/bin/google-chrome && sudo ln -s /usr/bin/chromium-browser  /usr/bin/google-chrome
     before_script:
       - cd ${COMPOSE_DIR}

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,14 +78,12 @@ matrix:
       - cd "${TRAVIS_BUILD_DIR}"
       - pip install -r dev-requirements.txt
 #      - wget https://chromedriver.storage.googleapis.com/73.0.3683.68/chromedriver_linux64.zip
-      - wget https://github.com/mozilla/geckodriver/releases/download/v0.25.0/geckodriver-v0.25.0-linux64.tar.gz
+#      - wget https://github.com/mozilla/geckodriver/releases/download/v0.25.0/geckodriver-v0.25.0-linux64.tar.gz
 #      - unzip chromedriver_linux64.zip
-      - tar -xvf geckodriver-v0.25.0-linux64.tar.gz
-      - sudo mv geckodriver /usr/local/bin
-      - chmod +x /usr/local/bin/geckodriver
+#      - tar -xvf geckodriver-v0.25.0-linux64.tar.gz
 #      - chmod 777  chromedriver
 #      - sudo mv  chromedriver /usr/local/bin/.
-      - sudo apt-get install firefox chromium-chromedriver chromium-browser
+      -  sudo apt-get install firefox firefox-geckodriver chromium-chromedriver chromium-browser
       -  sudo rm  /usr/bin/google-chrome && sudo ln -s /usr/bin/chromium-browser  /usr/bin/google-chrome
     before_script:
       - cd ${COMPOSE_DIR}

--- a/tests/integration/test_authflows.py
+++ b/tests/integration/test_authflows.py
@@ -46,6 +46,7 @@ class TestIntegrationApi(unittest.TestCase):
             self.assertTrue(False, msg="Could not load driver")
 
         try:
+            time.sleep(3)
             username_dom = driver.find_element_by_id("username")
             password_dom = driver.find_element_by_id("password")
 
@@ -70,7 +71,6 @@ class TestIntegrationApi(unittest.TestCase):
         options = FireFoxOptions()
         options.headless = True
         driver = webdriver.Firefox(options=options)  # requires geckodriver defined in $PATH
-        time.sleep(5)
         self.browser_login(driver)
 
     def testChromeAuthFlow(self):

--- a/tests/integration/test_authflows.py
+++ b/tests/integration/test_authflows.py
@@ -14,6 +14,9 @@ import logging
 from selenium import webdriver
 from selenium.webdriver.firefox.options import Options as FireFoxOptions
 from selenium.common.exceptions import NoSuchElementException, WebDriverException
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 
 logger = logging.getLogger(__file__)
@@ -46,8 +49,15 @@ class TestIntegrationApi(unittest.TestCase):
             self.assertTrue(False, msg="Could not load driver")
 
         try:
-            username_dom = driver.find_element_by_id("username")
-            password_dom = driver.find_element_by_id("password")
+            username_dom = WebDriverWait(driver, 5).until(
+                EC.presence_of_element_located((By.ID, "username"))
+            )
+
+            password_dom = WebDriverWait(driver, 5).until(
+                EC.presence_of_element_located((By.ID, "password"))
+            )
+
+            # password_dom = driver.find_element_by_id("password")
 
             username_dom.send_keys(TEST_USER)
             password_dom.send_keys(TEST_PW)
@@ -60,6 +70,9 @@ class TestIntegrationApi(unittest.TestCase):
             driver.quit()
 
         except NoSuchElementException:
+            driver.quit()
+            self.assertTrue(False, msg="Could not complete login/logout flow")
+        finally:
             driver.quit()
             self.assertTrue(False, msg="Could not complete login/logout flow")
 

--- a/tests/integration/test_authflows.py
+++ b/tests/integration/test_authflows.py
@@ -69,7 +69,7 @@ class TestIntegrationApi(unittest.TestCase):
         """
         options = FireFoxOptions()
         options.headless = True
-        driver = webdriver.Firefox(options=options, executable_path='/usr/local/bin/geckodriver')  # requires geckodriver defined in $PATH
+        driver = webdriver.Firefox(options=options)  # requires geckodriver defined in $PATH
         driver.implicitly_wait(5)
         self.browser_login(driver)
 

--- a/tests/integration/test_authflows.py
+++ b/tests/integration/test_authflows.py
@@ -69,7 +69,7 @@ class TestIntegrationApi(unittest.TestCase):
         """
         options = FireFoxOptions()
         options.headless = True
-        driver = webdriver.Firefox(options=options)  # requires geckodriver defined in $PATH
+        driver = webdriver.Firefox(options=options, executable_path='/usr/local/bin/geckodriver')  # requires geckodriver defined in $PATH
         self.browser_login(driver)
 
     def testChromeAuthFlow(self):

--- a/tests/integration/test_authflows.py
+++ b/tests/integration/test_authflows.py
@@ -70,7 +70,7 @@ class TestIntegrationApi(unittest.TestCase):
         """
         options = FireFoxOptions()
         options.headless = True
-        driver = webdriver.Firefox(options=options)  # requires geckodriver defined in $PATH
+        driver = webdriver.Firefox(options=options, executable_path='/usr/local/bin/geckodriver')  # requires geckodriver defined in $PATH
         self.browser_login(driver)
 
     def testChromeAuthFlow(self):

--- a/tests/integration/test_authflows.py
+++ b/tests/integration/test_authflows.py
@@ -69,7 +69,7 @@ class TestIntegrationApi(unittest.TestCase):
         """
         options = FireFoxOptions()
         options.headless = True
-        driver = webdriver.Firefox(options=options, executable_path='/usr/local/bin/geckodriver')  # requires geckodriver defined in $PATH
+        driver = webdriver.Firefox(options=options)  # requires geckodriver defined in $PATH
         time.sleep(5)
         self.browser_login(driver)
 

--- a/tests/integration/test_authflows.py
+++ b/tests/integration/test_authflows.py
@@ -70,6 +70,7 @@ class TestIntegrationApi(unittest.TestCase):
         options = FireFoxOptions()
         options.headless = True
         driver = webdriver.Firefox(options=options, executable_path='/usr/local/bin/geckodriver')  # requires geckodriver defined in $PATH
+        time.sleep(5)
         self.browser_login(driver)
 
     def testChromeAuthFlow(self):

--- a/tests/integration/test_authflows.py
+++ b/tests/integration/test_authflows.py
@@ -69,7 +69,7 @@ class TestIntegrationApi(unittest.TestCase):
         """
         options = FireFoxOptions()
         options.headless = True
-        driver = webdriver.Firefox(options=options, executable_path='/usr/local/bin/geckodriver')  # requires geckodriver defined in $PATH
+        driver = webdriver.Firefox(options=options)  # requires geckodriver defined in $PATH
         self.browser_login(driver)
 
     def testChromeAuthFlow(self):

--- a/tests/integration/test_authflows.py
+++ b/tests/integration/test_authflows.py
@@ -56,7 +56,7 @@ class TestIntegrationApi(unittest.TestCase):
             time.sleep(1.0)
             driver.find_element_by_id("user-dropdown-top").click()
             time.sleep(1.0)
-            driver.find_element_by_link_text(" Logout").click()
+            driver.find_element_by_link_text("Logout").click()
             driver.quit()
 
         except NoSuchElementException:

--- a/tests/integration/test_authflows.py
+++ b/tests/integration/test_authflows.py
@@ -46,7 +46,6 @@ class TestIntegrationApi(unittest.TestCase):
             self.assertTrue(False, msg="Could not load driver")
 
         try:
-            time.sleep(3)
             username_dom = driver.find_element_by_id("username")
             password_dom = driver.find_element_by_id("password")
 
@@ -71,6 +70,7 @@ class TestIntegrationApi(unittest.TestCase):
         options = FireFoxOptions()
         options.headless = True
         driver = webdriver.Firefox(options=options, executable_path='/usr/local/bin/geckodriver')  # requires geckodriver defined in $PATH
+        driver.implicitly_wait(5)
         self.browser_login(driver)
 
     def testChromeAuthFlow(self):

--- a/tests/integration/test_authflows.py
+++ b/tests/integration/test_authflows.py
@@ -82,7 +82,7 @@ class TestIntegrationApi(unittest.TestCase):
         """
         options = FireFoxOptions()
         options.headless = True
-        driver = webdriver.Firefox(options=options, executable_path='/usr/local/bin/geckodriver')  # requires geckodriver defined in $PATH
+        driver = webdriver.Firefox(options=options)  # requires geckodriver defined in $PATH
         self.browser_login(driver)
 
     def testChromeAuthFlow(self):

--- a/tests/integration/test_authflows.py
+++ b/tests/integration/test_authflows.py
@@ -63,7 +63,6 @@ class TestIntegrationApi(unittest.TestCase):
             driver.quit()
             self.assertTrue(False, msg="Could not complete login/logout flow")
 
-    @unittest.skip('Some day it will work')
     def testFirefoxAuthFlow(self):
         """
         Performs a Firefox browser login and logout

--- a/tests/integration/test_authflows.py
+++ b/tests/integration/test_authflows.py
@@ -56,7 +56,7 @@ class TestIntegrationApi(unittest.TestCase):
             time.sleep(1.0)
             driver.find_element_by_id("user-dropdown-top").click()
             time.sleep(1.0)
-            driver.find_element_by_link_text("Logout").click()
+            driver.find_element_by_link_text(" Logout").click()
             driver.quit()
 
         except NoSuchElementException:

--- a/tests/integration/test_authflows.py
+++ b/tests/integration/test_authflows.py
@@ -82,8 +82,7 @@ class TestIntegrationApi(unittest.TestCase):
         """
         options = FireFoxOptions()
         options.headless = True
-        driver = webdriver.Firefox(options=options)  # requires geckodriver defined in $PATH
-        driver.implicitly_wait(5)
+        driver = webdriver.Firefox(options=options, executable_path='/usr/local/bin/geckodriver')  # requires geckodriver defined in $PATH
         self.browser_login(driver)
 
     def testChromeAuthFlow(self):

--- a/tests/integration/test_authflows.py
+++ b/tests/integration/test_authflows.py
@@ -14,9 +14,6 @@ import logging
 from selenium import webdriver
 from selenium.webdriver.firefox.options import Options as FireFoxOptions
 from selenium.common.exceptions import NoSuchElementException, WebDriverException
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
 
 
 logger = logging.getLogger(__file__)
@@ -49,15 +46,8 @@ class TestIntegrationApi(unittest.TestCase):
             self.assertTrue(False, msg="Could not load driver")
 
         try:
-            username_dom = WebDriverWait(driver, 5).until(
-                EC.presence_of_element_located((By.ID, "username"))
-            )
-
-            password_dom = WebDriverWait(driver, 5).until(
-                EC.presence_of_element_located((By.ID, "password"))
-            )
-
-            # password_dom = driver.find_element_by_id("password")
+            username_dom = driver.find_element_by_id("username")
+            password_dom = driver.find_element_by_id("password")
 
             username_dom.send_keys(TEST_USER)
             password_dom.send_keys(TEST_PW)
@@ -72,9 +62,6 @@ class TestIntegrationApi(unittest.TestCase):
         except NoSuchElementException:
             driver.quit()
             self.assertTrue(False, msg="Could not complete login/logout flow")
-        finally:
-            driver.quit()
-            self.assertTrue(False, msg="Could not complete login/logout flow")
 
     def testFirefoxAuthFlow(self):
         """
@@ -82,7 +69,7 @@ class TestIntegrationApi(unittest.TestCase):
         """
         options = FireFoxOptions()
         options.headless = True
-        driver = webdriver.Firefox(options=options)  # requires geckodriver defined in $PATH
+        driver = webdriver.Firefox(options=options, executable_path='/usr/local/bin/geckodriver')  # requires geckodriver defined in $PATH
         self.browser_login(driver)
 
     def testChromeAuthFlow(self):


### PR DESCRIPTION
- Note to myself: remember to squash the commits!

Notes:
- While the reason for intermittent Firefox failing was not super clear, specifying `firefox: latest` did resolve this issue. 
- Chromium is used for now, as google-chrome was also problematic. This is just for future reference. In case we want to add google-chrome back.