### PR TITLE
Haoyuanli/feature 191203 new api and duo

### DIFF
--- a/candig/server/cli/repomanager.py
+++ b/candig/server/cli/repomanager.py
@@ -1324,7 +1324,6 @@ class RepoManager(object):
         subparser.add_argument(
             "dataUseOntologyFile", help="Path to your duo config json file.")
 
-
     @classmethod
     def addDatasetNameArgument(cls, subparser):
         subparser.add_argument(

--- a/candig/server/cli/repomanager.py
+++ b/candig/server/cli/repomanager.py
@@ -189,7 +189,7 @@ class RepoManager(object):
         dataset = datasets.Dataset(self._args.datasetName)
 
         with open(self._args.dataUseOntologyFile, 'r') as f:
-            duo_info  = json.load(f)
+            duo_info = json.load(f)
 
         ont = OntObjectInitiator("https://raw.githubusercontent.com/EBISPOT/DUO/master/src/ontology/duo-basic.owl").get_ont()
         validator = OntologyValidator(ont, duo_info)

--- a/candig/server/cli/repomanager.py
+++ b/candig/server/cli/repomanager.py
@@ -27,6 +27,7 @@ import candig.server.datamodel.peers as peers
 import candig.server.datarepo as datarepo
 import candig.server.exceptions as exceptions
 import candig.server.repo.rnaseq2ga as rnaseq2ga
+from candig.server.ontology import OntologyValidator, OntObjectInitiator
 
 import candig.common.cli as common_cli
 
@@ -140,7 +141,7 @@ class RepoManager(object):
         """
         self._openRepo()
         self._repo.printAnnouncements()
-        
+
     def clearAnnouncements(self):
         """
         Clears the list of announcements from the repo.
@@ -179,6 +180,27 @@ class RepoManager(object):
         dataset.setDescription(self._args.description)
         dataset.setAttributes(json.loads(self._args.attributes))
         self._updateRepo(self._repo.insertDataset, dataset)
+
+    def addDatasetDuo(self):
+        """
+        Adds DUO info to existing dataset into this repo.
+        """
+        self._validateRepo()
+        dataset = datasets.Dataset(self._args.datasetName)
+
+        with open(self._args.dataUseOntologyFile, 'r') as f:
+            duo_info  = json.load(f)
+
+        ont = OntObjectInitiator("https://raw.githubusercontent.com/EBISPOT/DUO/master/src/ontology/duo-basic.owl").get_ont()
+        validator = OntologyValidator(ont, duo_info)
+
+        # If the DUO Terms provided are valid.
+        if validator.validate_duo():
+            duo_list = validator.get_duo_list()
+            dataset.setDuoInfo(duo_list)
+            self._updateRepo(self._repo.updateDatasetDuo, dataset)
+        else:
+            print("Aborted.")
 
     def addReferenceSet(self):
         """
@@ -434,6 +456,17 @@ class RepoManager(object):
             self._updateRepo(self._repo.removeDataset, dataset)
         self._confirmDelete("Dataset", dataset.getLocalId(), func)
 
+    def removeDatasetDuo(self):
+        """
+        Removes a dataset's DUO info from the repo.
+        """
+        self._validateRepo()
+        dataset = self._repo.getSqlDatasetByName(self._args.datasetName)
+
+        def func():
+            self._updateRepo(self._repo.deleteDatasetDuo, dataset)
+        self._confirmDelete("the Data Use Ontology Info For Dataset", dataset.getLocalId(), func)
+
     def addFeatureSet(self):
         """
         Adds a new feature set into this repo
@@ -573,7 +606,7 @@ class RepoManager(object):
         def func():
             self._updateRepo(self._repo.removePatient, patient)
         self._confirmDelete("Patient", patient.getLocalId(), func)
-        
+
     def addEnrollment(self):
         """
         Adds a new enrollment into this repo
@@ -596,7 +629,7 @@ class RepoManager(object):
         def func():
             self._updateRepo(self._repo.removeEnrollment, enrollment)
         self._confirmDelete("Enrollment", enrollment.getLocalId(), func)
-        
+
     def addConsent(self):
         """
         Adds a new consent into this repo
@@ -619,7 +652,7 @@ class RepoManager(object):
         def func():
             self._updateRepo(self._repo.removeConsent, consent)
         self._confirmDelete("Consent", consent.getLocalId(), func)
-        
+
     def addDiagnosis(self):
         """
         Adds a new diagnosis into this repo
@@ -642,7 +675,7 @@ class RepoManager(object):
         def func():
             self._updateRepo(self._repo.removeDiagnosis, diagnosis)
         self._confirmDelete("Diagnosis", diagnosis.getLocalId(), func)
-        
+
     def addSample(self):
         """
         Adds a new sample into this repo
@@ -665,7 +698,7 @@ class RepoManager(object):
         def func():
             self._updateRepo(self._repo.removeSample, sample)
         self._confirmDelete("Sample", sample.getLocalId(), func)
-        
+
     def addTreatment(self):
         """
         Adds a new treatment into this repo
@@ -688,7 +721,7 @@ class RepoManager(object):
         def func():
             self._updateRepo(self._repo.removeTreatment, treatment)
         self._confirmDelete("Treatment", treatment.getLocalId(), func)
-        
+
     def addOutcome(self):
         """
         Adds a new outcome into this repo
@@ -711,7 +744,7 @@ class RepoManager(object):
         def func():
             self._updateRepo(self._repo.removeOutcome, outcome)
         self._confirmDelete("Outcome", outcome.getLocalId(), func)
-        
+
     def addComplication(self):
         """
         Adds a new complication into this repo
@@ -734,7 +767,7 @@ class RepoManager(object):
         def func():
             self._updateRepo(self._repo.removeComplication, complication)
         self._confirmDelete("Complication", complication.getLocalId(), func)
-        
+
     def addTumourboard(self):
         """
         Adds a new tumourboard into this repo
@@ -1287,6 +1320,12 @@ class RepoManager(object):
                 objectType))
 
     @classmethod
+    def addDuoArgument(cls, subparser):
+        subparser.add_argument(
+            "dataUseOntologyFile", help="Path to your duo config json file.")
+
+
+    @classmethod
     def addDatasetNameArgument(cls, subparser):
         subparser.add_argument(
             "datasetName", help="the name of the dataset")
@@ -1814,6 +1853,20 @@ class RepoManager(object):
         cls.addRepoArgument(removeDatasetParser)
         cls.addDatasetNameArgument(removeDatasetParser)
         cls.addForceOption(removeDatasetParser)
+
+        addDatasetDuoParser = common_cli.addSubparser(
+            subparsers, "add-dataset-duo", "Add DUO info to a dataset")
+        addDatasetDuoParser.set_defaults(runner="addDatasetDuo")
+        cls.addRepoArgument(addDatasetDuoParser)
+        cls.addDatasetNameArgument(addDatasetDuoParser)
+        cls.addDuoArgument(addDatasetDuoParser)
+
+        removeDatasetDuoParser = common_cli.addSubparser(
+            subparsers, "remove-dataset-duo", "Remove DUO info from a dataset")
+        removeDatasetDuoParser.set_defaults(runner="removeDatasetDuo")
+        cls.addRepoArgument(removeDatasetDuoParser)
+        cls.addDatasetNameArgument(removeDatasetDuoParser)
+        cls.addForceOption(removeDatasetDuoParser)
 
         addExperimentParser = common_cli.addSubparser(
             subparsers, "add-experiment", "Add an experiment to the data repo")
@@ -2580,6 +2633,7 @@ def getRepoManagerParser():
 def repoExitError(message):
     """
     Exits the repo manager with error status.
+    TODO: Look into how the message is formatted
     """
     wrapper = textwrap.TextWrapper(
         break_on_hyphens=False, break_long_words=False)
@@ -2601,6 +2655,12 @@ def repo_main(args=None):
     except exceptions.DataException as exception:
         # We expect DataExceptions to occur when a file open fails,
         # a URL cannot be reached, etc.
+        repoExitError(str(exception))
+    except exceptions.NoInternetConnectionException as exception:
+        # When there's no internet at the time of ingesting ontology file
+        repoExitError(str(exception))
+    except exceptions.FailToParseOntologyException as exception:
+        # When the Ontology file is corrupted
         repoExitError(str(exception))
     except Exception as exception:
         # Uncaught exception: this is a bug

--- a/candig/server/cli/repomanager.py
+++ b/candig/server/cli/repomanager.py
@@ -190,7 +190,7 @@ class RepoManager(object):
 
         try:
             with open(self._args.dataUseOntologyFile, 'r') as f:
-                duo_info  = json.load(f)
+                duo_info = json.load(f)
         except (json.decoder.JSONDecodeError, FileNotFoundError) as e:
             raise exceptions.JsonFileOpenException(e)
 

--- a/candig/server/cli/repomanager.py
+++ b/candig/server/cli/repomanager.py
@@ -188,8 +188,11 @@ class RepoManager(object):
         self._validateRepo()
         dataset = datasets.Dataset(self._args.datasetName)
 
-        with open(self._args.dataUseOntologyFile, 'r') as f:
-            duo_info = json.load(f)
+        try:
+            with open(self._args.dataUseOntologyFile, 'r') as f:
+                duo_info  = json.load(f)
+        except (json.decoder.JSONDecodeError, FileNotFoundError) as e:
+            raise exceptions.JsonFileOpenException(e)
 
         ont = OntObjectInitiator("https://raw.githubusercontent.com/EBISPOT/DUO/master/src/ontology/duo-basic.owl").get_ont()
         validator = OntologyValidator(ont, duo_info)

--- a/candig/server/cli/repomanager.py
+++ b/candig/server/cli/repomanager.py
@@ -27,7 +27,7 @@ import candig.server.datamodel.peers as peers
 import candig.server.datarepo as datarepo
 import candig.server.exceptions as exceptions
 import candig.server.repo.rnaseq2ga as rnaseq2ga
-from candig.server.ontology import OntologyValidator, OntObjectInitiator
+from candig.server.ontology import OntologyValidator
 
 import candig.common.cli as common_cli
 
@@ -194,8 +194,7 @@ class RepoManager(object):
         except (json.decoder.JSONDecodeError, FileNotFoundError) as e:
             raise exceptions.JsonFileOpenException(e)
 
-        ont = OntObjectInitiator("https://raw.githubusercontent.com/EBISPOT/DUO/master/src/ontology/duo-basic.owl").get_ont()
-        validator = OntologyValidator(ont, duo_info)
+        validator = OntologyValidator(duo_info)
 
         # If the DUO Terms provided are valid.
         if validator.validate_duo():

--- a/candig/server/datamodel/datasets.py
+++ b/candig/server/datamodel/datasets.py
@@ -1,7 +1,7 @@
 """
 Dataset objects
 """
-
+import json
 import candig.server.datamodel as datamodel
 import candig.server.datamodel.reads as reads
 import candig.server.datamodel.sequence_annotations as sequence_annotations
@@ -11,6 +11,7 @@ import candig.server.exceptions as exceptions
 import candig.server.datamodel.bio_metadata as biodata
 import candig.server.datamodel.genotype_phenotype as g2p
 import candig.server.datamodel.rna_quantification as rnaQuantification
+from candig.server.ontology import OntologyParser, OntObjectInitiator
 
 import candig.schemas.pb as pb
 import candig.schemas.protocol as protocol
@@ -134,7 +135,7 @@ class Dataset(datamodel.DatamodelObject):
         self._labtestIds = []
         self._labtestIdMap = {}
         self._labtestNameMap = {}
-        
+
         # Extraction
         self._extractionIds = []
         self._extractionIdMap = {}
@@ -173,11 +174,41 @@ class Dataset(datamodel.DatamodelObject):
         self._description = dataset.description
         self.setAttributesJson(dataset.attributes)
 
+    def populateDuoInfo(self, dataset):
+        """
+        Populates DUO info by attaching definition to the DUO term.
+        """
+        if dataset.info is not None:
+            parsed_info = json.loads(dataset.info)
+
+            ont = OntObjectInitiator("https://raw.githubusercontent.com/EBISPOT/DUO/master/src/ontology/duo-basic.owl").get_ont()
+
+            results = []
+
+            for term in parsed_info:
+                term_parser = OntologyParser(ont, term["id"])
+                term["term_id"] = term["id"]
+                term["shorthand"] = term_parser.get_shorthand()
+                term["definition"] = term_parser.get_definition()
+                term["term"] = term_parser.get_name()
+
+                results.append(term)
+
+            self._info = results
+        else:
+            self._info = []
+
     def setDescription(self, description):
         """
         Sets the description for this dataset to the specified value.
         """
         self._description = description
+
+    def setDuoInfo(self, duo_list):
+        """
+        Sets the DUO list of this dataset.
+        """
+        self._info = duo_list
 
     def addVariantSet(self, variantSet):
         """
@@ -457,6 +488,8 @@ class Dataset(datamodel.DatamodelObject):
         dataset.id = self.getId()
         dataset.name = pb.string(self.getLocalId())
         dataset.description = pb.string(self.getDescription())
+        # Populate DUO info by extending the list
+        dataset.terms_of_use.extend([protocol.fromJson(json.dumps(p), protocol.OntologyTerm) for p in self.getInfo()])
         self.serializeAttributes(dataset)
         return dataset
 

--- a/candig/server/datamodel/datasets.py
+++ b/candig/server/datamodel/datasets.py
@@ -26,6 +26,7 @@ class Dataset(datamodel.DatamodelObject):
     def __init__(self, localId):
         super(Dataset, self).__init__(None, localId)
         self._description = None
+        self._info = []
         self._variantSetIds = []
         self._variantSetIdMap = {}
         self._variantSetNameMap = {}
@@ -1336,6 +1337,7 @@ class SimulatedDataset(Dataset):
             numExpressionLevels=2):
         super(SimulatedDataset, self).__init__(localId)
         self._description = "Simulated dataset {}".format(localId)
+        self._info = [{"id": "DUO:0000042"}]
 
         for i in range(numPhenotypeAssociationSets):
             localId = "simPas{}".format(i)

--- a/candig/server/datarepo.py
+++ b/candig/server/datarepo.py
@@ -1163,13 +1163,13 @@ class SqlDataRepository(AbstractDataRepository):
         """
         Create or update the DUO info of a dataset
         """
-        models.Dataset.update({models.Dataset.info: dataset._info}).where(models.Dataset.id==dataset.getId()).execute()
+        models.Dataset.update({models.Dataset.info: dataset._info}).where(models.Dataset.id == dataset.getId()).execute()
 
     def deleteDatasetDuo(self, dataset):
         """
         Delete the DUO info of a dataset
         """
-        models.Dataset.update({models.Dataset.info: None}).where(models.Dataset.id==dataset.getId()).execute()
+        models.Dataset.update({models.Dataset.info: None}).where(models.Dataset.id == dataset.getId()).execute()
 
     def removeDataset(self, dataset):
         """

--- a/candig/server/datarepo.py
+++ b/candig/server/datarepo.py
@@ -1159,6 +1159,18 @@ class SqlDataRepository(AbstractDataRepository):
             raise exceptions.DuplicateNameException(
                 dataset.getLocalId())
 
+    def updateDatasetDuo(self, dataset):
+        """
+        Create or update the DUO info of a dataset
+        """
+        models.Dataset.update({models.Dataset.info: dataset._info}).where(models.Dataset.id==dataset.getId()).execute()
+
+    def deleteDatasetDuo(self, dataset):
+        """
+        Delete the DUO info of a dataset
+        """
+        models.Dataset.update({models.Dataset.info: None}).where(models.Dataset.id==dataset.getId()).execute()
+
     def removeDataset(self, dataset):
         """
         Removes the specified dataset from this repository. This performs
@@ -1197,6 +1209,7 @@ class SqlDataRepository(AbstractDataRepository):
         for datasetRecord in models.Dataset.select():
             dataset = datasets.Dataset(datasetRecord.name)
             dataset.populateFromRow(datasetRecord)
+            dataset.populateDuoInfo(datasetRecord)
             assert dataset.getId() == datasetRecord.id
             # Insert the dataset into the memory-based object model.
             self.addDataset(dataset)

--- a/candig/server/exceptions.py
+++ b/candig/server/exceptions.py
@@ -712,6 +712,13 @@ class FileOpenFailedException(DataException):
         self.message = "Failed to open file '{}'".format(filename)
 
 
+class JsonFileOpenException(DataException):
+
+    def __init__(self, message):
+        self.message = "You need to provide a valid JSON file. It failed to " \
+                       "be processed because '{}'.".format(message)
+
+
 class EmptyDirException(DataException):
 
     def __init__(self, dirname, filetype):

--- a/candig/server/exceptions.py
+++ b/candig/server/exceptions.py
@@ -184,6 +184,16 @@ class InvalidLogicException(BadRequestException):
         self.message = "Invalid logic formatting: " + field
 
 
+class NoInternetConnectionException(RuntimeException):
+    def __init__(self):
+        self.message = "The DUO OWL file cannot be retrieved. Please make sure you have an active internet connection."
+
+
+class FailToParseOntologyException(RuntimeException):
+    def __init__(self):
+        self.message = "The ontology file cannot be parsed."
+
+
 class Validator(object):
     """
     Check that a JSON dictionary is a valid representation of a protocol

--- a/candig/server/ontology.py
+++ b/candig/server/ontology.py
@@ -100,17 +100,15 @@ class OntologyValidator():
 
     Example Usage:
 
-    from pronto import Ontology
-    ont = Ontology("https://raw.githubusercontent.com/EBISPOT/DUO/master/src/ontology/duo-basic.owl")
-    validator = OntologyValidator(ont, "duo_input.json")
+	with open("duo.json", 'r') as f:
+		validator = OntologyValidator(f)
 
-    if validator.validate_duo() is True:
-        terms = validator.get_duo_list()
+	    if validator.validate_duo():
+	        terms = validator.get_duo_list()
 
     """
 
-    def __init__(self, ont, input_json):
-        self.ontology_file_object = ont
+    def __init__(self, input_json):
         self.input_json = input_json
         self.ids_require_datetime_modifier = ["DUO:0000024"]
         self.ids_supported = [
@@ -118,9 +116,8 @@ class OntologyValidator():
             "DUO:0000005", "DUO:0000006", "DUO:0000007", "DUO:0000011",
             "DUO:0000012", "DUO:0000014", "DUO:0000015", "DUO:0000016",
             "DUO:0000017", "DUO:0000018", "DUO:0000019", "DUO:0000020",
-            "DUO:0000021", "DUO:0000022", "DUO:0000024", "DUO:0000025",
-            "DUO:0000026", "DUO:0000027", "DUO:0000028", "DUO:0000029",
-            "DUO:0000042"
+            "DUO:0000021", "DUO:0000024", "DUO:0000026", "DUO:0000027",
+            "DUO:0000028", "DUO:0000029", "DUO:0000042"
         ]
         self.ids_need_modifiers_with_def = {
             "DUO:0000024": "This DUO Term requires you specify date as YYYY-MM-DD format in the modifier attribute."
@@ -139,7 +136,7 @@ class OntologyValidator():
             duo_id = duo.get("id")
             modifier = duo.get("modifier")
 
-            # Fail is the ID is None
+            # Fail if the ID is None
             if duo_id is None:
                 validity = False
                 print("Please specify 'id' for all DUO terms.")

--- a/candig/server/ontology.py
+++ b/candig/server/ontology.py
@@ -100,11 +100,11 @@ class OntologyValidator():
 
     Example Usage:
 
-	with open("duo.json", 'r') as f:
-		validator = OntologyValidator(f)
+    with open("duo.json", 'r') as f:
+        validator = OntologyValidator(f)
 
-	    if validator.validate_duo():
-	        terms = validator.get_duo_list()
+    if validator.validate_duo():
+        terms = validator.get_duo_list()
 
     """
 

--- a/candig/server/ontology.py
+++ b/candig/server/ontology.py
@@ -1,0 +1,219 @@
+import json
+import warnings
+from datetime import datetime
+
+import candig.server.exceptions as exceptions
+
+from pronto import Ontology
+
+
+class OntologyFile():
+    """
+    Get a list of ontology terms of an ontology file.
+
+    Example usage:
+
+    from pronto import Ontology
+    ont = Ontology("https://raw.githubusercontent.com/EBISPOT/DUO/master/src/ontology/duo-basic.owl")
+    duos = OntologyFile(ont)
+    duo_terms = duos.get_terms()
+    """
+
+    def __init__(self, ont):
+        """
+        ont
+        """
+        self.ontology_file_object = ont
+
+    def get_terms(self):
+        res = []
+
+        for term in self.ontology_file_object.terms():
+            obj = {}
+            obj['id'] = term.id
+            obj['name'] = term.name
+            res.append(obj)
+
+        return res
+
+
+class OntologyParser():
+    """
+    This class provides methods to get the attributes of an ontology term.
+
+    Example usage:
+
+    from pronto import Ontology
+    ont = Ontology("https://raw.githubusercontent.com/EBISPOT/DUO/master/src/ontology/duo-basic.owl")
+    duo = OntologyParser(ont, "DUO:0000025")
+    term_overview = duo.get_overview()
+    """
+
+    def __init__(self, ont, term_id):
+        self.ontology_term_object = ont[term_id]
+        self.shorthand_prop = "http://www.geneontology.org/formats/oboInOwl#shorthand"
+
+    def get_term_id(self):
+        return self.ontology_term_object.id
+
+    def get_shorthand(self):
+        annotations = self.ontology_term_object.annotations
+        return next((pv.literal for pv in annotations if pv.property == self.shorthand_prop), None)
+
+    def get_name(self):
+        return self.ontology_term_object.name
+
+    def get_definition(self):
+        return str(self.ontology_term_object.definition)
+
+    def get_comment(self):
+        return self.ontology_term_object.comment
+
+    def get_relationships(self):
+        relationships = self.ontology_term_object.relationships
+        res = {}
+
+        for rel_key in relationships:
+            res[rel_key.id] = next(iter(relationships[rel_key])).id
+
+        return res
+
+    def get_overview(self):
+        res = {}
+        res["shorthand"] = self.get_shorthand()
+        res["name"] = self.get_name()
+        res["definition"] = self.get_definition()
+        res["relationships"] = self.get_relationships()
+
+        return res
+
+
+class OntologyValidator():
+    """
+    Validate a json file that contains Data Use Ontology information.
+    The file should be formatted as {"duo": []}, with the value being a list of DUO objects.
+    All DUO objects must contain an 'id' field, selected 'id's need to have 'modifier'.
+
+    Example input file:
+
+    {"duo": [{"id": "DUO:0000018"}, {"id": "DUO:0000025", "modifier": "2030-01-01"}]}
+
+    Example Usage:
+
+    from pronto import Ontology
+    ont = Ontology("https://raw.githubusercontent.com/EBISPOT/DUO/master/src/ontology/duo-basic.owl")
+    validator = OntologyValidator(ont, "duo_input.json")
+
+    if validator.validate_duo() is True:
+        terms = validator.get_duo_list()
+
+    """
+
+    def __init__(self, ont, input_json):
+        self.ontology_file_object = ont
+        self.input_json = input_json
+        self.ids_require_datetime_modifier = ["DUO:0000024"]
+        self.ids_supported = [
+            "DUO:0000001", "DUO:0000002", "DUO:0000003", "DUO:0000004",
+            "DUO:0000005", "DUO:0000006", "DUO:0000007", "DUO:0000011",
+            "DUO:0000012", "DUO:0000014", "DUO:0000015", "DUO:0000016",
+            "DUO:0000017", "DUO:0000018", "DUO:0000019", "DUO:0000020",
+            "DUO:0000021", "DUO:0000022", "DUO:0000024", "DUO:0000025",
+            "DUO:0000026", "DUO:0000027", "DUO:0000028", "DUO:0000029",
+            "DUO:0000042"
+        ]
+        self.ids_need_modifiers_with_def = {
+            "DUO:0000024": "This DUO Term requires you specify date as YYYY-MM-DD format in the modifier attribute."
+        }
+
+    def validate_duo(self):
+        validity = True
+        duo_list = self.input_json.get('duo')
+
+        # if duo_list is empty or None, abort validation right away
+        if not duo_list:
+            return False
+
+        for duo in duo_list:
+            try:
+                duo_id = duo.get("id")
+                modifier = duo.get("modifier")
+
+                # Check if the ID exists, a KeyError will be thrown is it doesn't
+                duo_term = OntologyParser(self.ontology_file_object, duo_id)
+
+                # Fail is the ID is None
+                if duo_id is None:
+                    validity = False
+                    print("Please specify 'id' for all DUO terms.")
+
+                # Fail if the ID supplied is unsupported
+                if duo_id not in self.ids_supported:
+                    validity = False
+                    print(duo_id, "is not currently supported.")
+
+                # Fail if the modifier is not supplied with IDs that require it
+                if duo_id in self.ids_need_modifiers_with_def and modifier is None:
+                    validity = False
+                    print(duo_id, self.ids_need_modifiers_with_def[duo_id])
+
+                # Fail if the datetime supplied with the IDs that require it is invalid
+                if duo_id in self.ids_require_datetime_modifier:
+                    if self.validate_date_time(modifier) is False:
+                        validity = False
+                        print(duo_id, "has malformed datetime", modifier, "it should be YYYY-MM-DD")
+
+                # Fail if modifier is supplied with IDs that do not require it
+                if modifier is not None and duo_id not in self.ids_need_modifiers_with_def:
+                    validity = False
+                    print(duo_id, "cannot accept a modifier.")
+
+            except KeyError:
+                # Fail if the ID cannot be found in ontology
+                validity = False
+                print("One or more DUO IDs you provide are not valid.")
+
+        return validity
+
+    def validate_date_time(self, date):
+        # Return True only if the date is formatted as YYYY-MM-DD
+        try:
+            datetime.strptime(str(date), "%Y-%m-%d")
+        except ValueError:
+            return False
+
+        return True
+
+    def get_duo_list(self):
+
+        duo_list = self.input_json['duo']
+        return json.dumps(duo_list)
+
+
+class OntObjectInitiator():
+    """
+    This class makes it easier to initiate pronto Ontology object.
+
+    Usage:
+    ont = OntObjectInitiator("https://raw.githubusercontent.com/EBISPOT/DUO/master/src/ontology/duo-basic.owl").get_ont()
+    term = OntologyParser(ont, "DUO:0000024")
+    """
+
+    def __init__(self, url):
+        self.ontology_link = url
+
+    def get_ont(self):
+        """
+        Return an Ontology object that is ready to use.
+        """
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore")
+
+            try:
+                return Ontology(self.ontology_link)
+            except ValueError:
+                # Fail to parse
+                raise exceptions.FailToParseOntologyException()
+            except Exception:
+                # from None suppresses all previous exceptions.
+                raise exceptions.NoInternetConnectionException() from None

--- a/candig/server/ontology.py
+++ b/candig/server/ontology.py
@@ -140,7 +140,7 @@ class OntologyValidator():
                 modifier = duo.get("modifier")
 
                 # Check if the ID exists, a KeyError will be thrown is it doesn't
-                duo_term = OntologyParser(self.ontology_file_object, duo_id)
+                OntologyParser(self.ontology_file_object, duo_id)
 
                 # Fail is the ID is None
                 if duo_id is None:

--- a/candig/server/ontology.py
+++ b/candig/server/ontology.py
@@ -135,43 +135,35 @@ class OntologyValidator():
             return False
 
         for duo in duo_list:
-            try:
-                duo_id = duo.get("id")
-                modifier = duo.get("modifier")
 
-                # Check if the ID exists, a KeyError will be thrown is it doesn't
-                OntologyParser(self.ontology_file_object, duo_id)
+            duo_id = duo.get("id")
+            modifier = duo.get("modifier")
 
-                # Fail is the ID is None
-                if duo_id is None:
-                    validity = False
-                    print("Please specify 'id' for all DUO terms.")
-
-                # Fail if the ID supplied is unsupported
-                if duo_id not in self.ids_supported:
-                    validity = False
-                    print(duo_id, "is not currently supported.")
-
-                # Fail if the modifier is not supplied with IDs that require it
-                if duo_id in self.ids_need_modifiers_with_def and modifier is None:
-                    validity = False
-                    print(duo_id, self.ids_need_modifiers_with_def[duo_id])
-
-                # Fail if the datetime supplied with the IDs that require it is invalid
-                if duo_id in self.ids_require_datetime_modifier:
-                    if self.validate_date_time(modifier) is False:
-                        validity = False
-                        print(duo_id, "has malformed datetime", modifier, "it should be YYYY-MM-DD")
-
-                # Fail if modifier is supplied with IDs that do not require it
-                if modifier is not None and duo_id not in self.ids_need_modifiers_with_def:
-                    validity = False
-                    print(duo_id, "cannot accept a modifier.")
-
-            except KeyError:
-                # Fail if the ID cannot be found in ontology
+            # Fail is the ID is None
+            if duo_id is None:
                 validity = False
-                print("One or more DUO IDs you provide are not valid.")
+                print("Please specify 'id' for all DUO terms.")
+
+            # Fail if the ID supplied is unsupported
+            if duo_id not in self.ids_supported:
+                validity = False
+                print(duo_id, "is not supported.")
+
+            # Fail if the modifier is not supplied with IDs that require it
+            if duo_id in self.ids_need_modifiers_with_def and modifier is None:
+                validity = False
+                print(duo_id, self.ids_need_modifiers_with_def[duo_id])
+
+            # Fail if the datetime supplied with the IDs that require it is invalid
+            if duo_id in self.ids_require_datetime_modifier:
+                if self.validate_date_time(modifier) is False:
+                    validity = False
+                    print(duo_id, "has malformed datetime", modifier, "it should be YYYY-MM-DD")
+
+            # Fail if modifier is supplied with IDs that do not require it
+            if modifier is not None and duo_id not in self.ids_need_modifiers_with_def:
+                validity = False
+                print(duo_id, "cannot accept a modifier.")
 
         return validity
 
@@ -179,7 +171,7 @@ class OntologyValidator():
         # Return True only if the date is formatted as YYYY-MM-DD
         try:
             datetime.strptime(str(date), "%Y-%m-%d")
-        except ValueError:
+        except (ValueError, TypeError):
             return False
 
         return True

--- a/candig/server/static/api.yaml
+++ b/candig/server/static/api.yaml
@@ -3,14 +3,13 @@ info:
   title: CanDIG Services
   description: |-
 
-    Below is a list of APIs that CanDIG currently supports.
-    
-    At this time, this page does not contain any information for /search and /count endpoints. For /search and /count endpoints, refer to [this documentation](https://www.distributedgenomics.ca/static/search_count_services_usage.pdf) for instructions and sample queries.<br/>
-    
-    For all metadata and variant services endpoints, you can also refer to [this documentation](https://www.distributedgenomics.ca/static/metadata_variants_services_sample_queries.pdf) for some ready-to-use sample queries.
-
+    ## Below is a list of APIs that CanDIG currently supports.
     ---
-    *Warning: developers, while reasonable efforts have been made to validate all the requests and response schemas listed here, at this time, we cannot guarantee that the spec to be fully openAPI compatiable or machine-readable. However, if you do encounter any issues, please let us know.*
+    ## You should refer to the API Usage section under our [Read the Docs](https://candig-server.readthedocs.io) for instructions and sample queries for variants, metadata, search and count services.
+
+    ## The API definition for /search and /count endpoints is not here, please select their definition on the top right corner.
+    ---
+    ### Warning: developers, while reasonable efforts have been made to validate all the requests and response schemas listed here, at this time, we cannot guarantee that the spec to be fully machine-readable. However, if you do encounter any issues, please let us know.
     ---
 
   version: "1.1"
@@ -2053,6 +2052,7 @@ components:
             $ref: '#/components/schemas/candigAttributeValueList'
     candigDataset:
       type: object
+      required: [id, name]
       properties:
         id:
           type: string
@@ -2066,6 +2066,12 @@ components:
           type: string
           description: Additional, human-readable information on the dataset.
           example: A mock dataset.
+        termsOfUse:
+          type: array
+          description: Optional. A list of Data Use Ontology terms that describe the terms of use for this dataset.
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/candigOntologyTerm'
       description: |-
         A Dataset is a collection of related data of multiple types.
         Data providers decide how to group data into datasets.
@@ -2185,21 +2191,30 @@ components:
       - NULL_VALUE
     candigOntologyTerm:
       title: |-
-        An ontology term describing an attribute. (e.g. the phenotype attribute
-        'polydactyly' from HPO)
+        Ontology term.
       type: object
       properties:
-        term_id:
+        termId:
           type: string
-          description: |-
-            Ontology term identifier - the CURIE for an ontology term. It
-            differs from the standard candig schema's :ref:id <apidesign_object_ids>
-            in that it is a CURIE pointing to an information resource outside of the
-            scope of the schema or its resource implementation.
+          example: DUO:00000042
+          description: The unique identifier of the term.
         term:
           type: string
+          example: General Research Use
           description: Ontology term - the label of the ontology term the termId is
             pointing to.
+        shorthand:
+          type: string
+          example: GRU
+          description: Shorthand of the term name. Only used in Data Use Ontology. This field may not be returned at all time.
+        definition:
+          type: string
+          example: This code indicates that it is only for general research use.
+          description: A text description of the ontology term.
+        modifier:
+          type: string
+          nullable: true
+          description: An additional comment on the term. Only used in Data Use Ontology. This field may not be returned at all time.
     candigProgram:
       type: object
       properties:

--- a/candig/server/static/search_count_service.yaml
+++ b/candig/server/static/search_count_service.yaml
@@ -3,10 +3,11 @@ info:
   title: CanDIG Search and Count Services
   description: |-
 
-    Below is the search and count API description.
+    ## Below is the search and count API description. Note that this was primarily prepared for advanced users. You should refer to the API Usage section under our [Read the Docs](https://candig-server.readthedocs.io) for more instructions.
 
+    ## If you wish to view the UI for all other endpoints, please select their definition on the top right corner.
     ---
-    *Warning: developers, This spec is not really machine-readable. Please use with caution.
+    ### Warning: developers, This spec is not really machine-readable. Please use with caution. In particular, we are unable to provide accurate machine-readable definitions for the Response of `/count` endpoint. We are also unable to express the recursive relations of the `logic` component of the complex requests.
     ---
 
   version: "1.1"

--- a/candig/server/templates/swagger.html
+++ b/candig/server/templates/swagger.html
@@ -28,9 +28,6 @@
         background: #fafafa;
       }
 
-      .swagger-ui .topbar {
-        display: none;
-      }
     </style>
   </head>
 
@@ -44,7 +41,7 @@
 
       // Begin Swagger UI call region
       const ui = SwaggerUIBundle({
-        url: "/static/output.swagger.json",
+        urls: [{"url": "/static/api.yaml", "name": "CanDIG Services"}, {"url": "/static/search_count_api.yaml", "name": "CanDIG Search and Count Services"}],
         dom_id: '#swagger-ui',
         deepLinking: true,
         validatorUrl: null,

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -188,7 +188,7 @@ the `id` along with the `modifier`.
 
 When your file is ready, run the `add-dataset-duo` command to populate the DUO information
 of the dataset. Please note that this command will always overwrite the existing DUO
-information stored. Detailed instructions are
+information stored.
 
 
 ------------------------------------

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -145,6 +145,9 @@ of DUO's `raw OWL definition <https://github.com/EBISPOT/DUO/blob/master/src/ont
     Terms whose ID has an underscore, such as `DUO_0000031`, as well as `DUO:0000022` and `DUO:0000025` are not
     supported, as we expect these terms to be updated in the near future.
 
+    If you think an ID should be supported, but is not. You can let us know by opening an issue
+    on our Github repo.
+
     The supported IDs are listed below.
 
 .. code-block:: json
@@ -153,8 +156,8 @@ of DUO's `raw OWL definition <https://github.com/EBISPOT/DUO/blob/master/src/ont
         "DUO:0000001", "DUO:0000002", "DUO:0000003", "DUO:0000004", "DUO:0000005",
         "DUO:0000006", "DUO:0000007", "DUO:0000011", "DUO:0000012", "DUO:0000014",
         "DUO:0000015", "DUO:0000016", "DUO:0000017", "DUO:0000018", "DUO:0000019",
-        "DUO:0000020", "DUO:0000021", "DUO:0000022", "DUO:0000024", "DUO:0000025",
-        "DUO:0000026", "DUO:0000027", "DUO:0000028", "DUO:0000029", "DUO:0000042"
+        "DUO:0000020", "DUO:0000021", "DUO:0000024", "DUO:0000026", "DUO:0000027"
+        "DUO:0000028", "DUO:0000029", "DUO:0000042"
     ]
 
 .. note::

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -131,21 +131,42 @@ It is available from here: https://github.com/CanDIG/redcap-cloud
 Data Use Ontology
 ------------------
 
-.. warning::
-
-    This section is highly experimental, and is subject to change until further notice.
-
 To enable future automated discovery, we have adopted the use of `Data Use Ontology (DUO)`
 Terms to describe our datasets. For the current version of candig-server, you have
 the option to use a json file to define your dataset.
 
-You can find a list of DUO Terms `here <https://github.com/EBISPOT/DUO/blob/master/src/ontology/duo.csv>`_.
+You can find a list of DUO Terms through this `csv file <https://github.com/EBISPOT/DUO/blob/master/src/ontology/duo.csv>`_.
+You can also use an ontology parsing tool of your choice to visualize/parse a more complete list
+of DUO's `raw OWL definition <https://github.com/EBISPOT/DUO/blob/master/src/ontology/duo-basic.owl>`_.
 
 .. warning::
-    `DUO:0000025` and `DUO:0000022` are not currently supported. Attempts to ingest them two
-    DUO Terms will be rejected.
+    We only support a limited subset of the DUO terms.
 
-To ingest the DUO Terms, you need to prepare a json file listed like below.
+    Terms whose ID has an underscore, such as `DUO_0000031`, as well as `DUO:0000022` and `DUO:0000025` are not
+    supported, as we expect these terms to be updated in the near future.
+
+    The supported IDs are listed below.
+
+.. code-block:: json
+
+    [
+        "DUO:0000001", "DUO:0000002", "DUO:0000003", "DUO:0000004", "DUO:0000005",
+        "DUO:0000006", "DUO:0000007", "DUO:0000011", "DUO:0000012", "DUO:0000014",
+        "DUO:0000015", "DUO:0000016", "DUO:0000017", "DUO:0000018", "DUO:0000019",
+        "DUO:0000020", "DUO:0000021", "DUO:0000022", "DUO:0000024", "DUO:0000025",
+        "DUO:0000026", "DUO:0000027", "DUO:0000028", "DUO:0000029", "DUO:0000042"
+    ]
+
+.. note::
+    We do not currently provide API to look up the definitions via their ID.
+
+    If one of the supported ids listed above is not in the csv file provided above, you may
+    be able to look up their definitions via `EBI's DUO page <https://www.ebi.ac.uk/ols/ontologies/duo>`_.
+
+
+To ingest the DUO Terms, you need to prepare a json file listed like below. You should only
+specify `id` in a single DUO object, unless the `modifier` is also required, then you specify
+the `id` along with the `modifier`.
 
 .. code-block:: json
 
@@ -167,7 +188,7 @@ To ingest the DUO Terms, you need to prepare a json file listed like below.
 
 When your file is ready, run the `add-dataset-duo` command to populate the DUO information
 of the dataset. Please note that this command will always overwrite the existing DUO
-information stored.
+information stored. Detailed instructions are
 
 
 ------------------------------------

--- a/docs/datarepo.rst
+++ b/docs/datarepo.rst
@@ -147,8 +147,6 @@ Create/update new Data Use Ontology Information for an existing dataset. Note th
 have an existing dataset to be able to use this command. When you need to update the DUO info,
 simply run the command with updated DUO Json file.
 
-Please note that as of now, you need to have an active internet connection to be able to use this,
-as the server attempts to download the latest DUO definition file.
 
 .. argparse::
    :module: candig.server.cli.repomanager
@@ -165,8 +163,8 @@ as the server attempts to download the latest DUO definition file.
 
 Adds the Data Use Ontology info to the  dataset with the name ``mock1``.
 
-To learn about how to prepare a json file that contains DUO info for a dataset,
-see the ``Data Use Ontology`` section under :ref:`data`.
+To learn about how to prepare a json file that contains DUO info for a dataset, and a list
+of DUO IDs that are allowed, see the ``Data Use Ontology`` section under :ref:`data`.
 
 
 --------------

--- a/docs/datarepo.rst
+++ b/docs/datarepo.rst
@@ -139,6 +139,36 @@ Adds the dataset with the name ``1kg`` and description
 registry database ``registry.db``.
 
 
+----------------------
+add-dataset-duo
+----------------------
+
+Create/update new Data Use Ontology Information for an existing dataset. Note that you have to
+have an existing dataset to be able to use this command. When you need to update the DUO info,
+simply run the command with updated DUO Json file.
+
+Please note that as of now, you need to have an active internet connection to be able to use this,
+as the server attempts to download the latest DUO definition file.
+
+.. argparse::
+   :module: candig.server.cli.repomanager
+   :func: getRepoManagerParser
+   :prog: candig_repo
+   :path: add-dataset-duo
+   :nodefault:
+
+**Examples:**
+
+.. code-block:: bash
+
+    $ candig_repo add-dataset-duo registry.db mock1 duo.json
+
+Adds the Data Use Ontology info to the  dataset with the name ``mock1``.
+
+To learn about how to prepare a json file that contains DUO info for a dataset,
+see the ``Data Use Ontology`` section under :ref:`data`.
+
+
 --------------
 remove-dataset
 --------------
@@ -162,6 +192,27 @@ objects (ReadGroupSets, VariantSets, etc) within this dataset.
 Deletes the dataset with name ``dataset1`` from the repository
 represented by ``registry.db``
 
+
+----------------------
+remove-dataset-duo
+----------------------
+
+Remove new Data Use Ontology Information for an existing dataset.
+
+.. argparse::
+   :module: candig.server.cli.repomanager
+   :func: getRepoManagerParser
+   :prog: candig_repo
+   :path: remove-dataset-duo
+   :nodefault:
+
+**Examples:**
+
+.. code-block:: bash
+
+    $ candig_repo remove-dataset-duo registry.db mock1
+
+Removes the Data Use Ontology info to the  dataset with the name ``mock1``.
 
 
 +++++++++++++++++++++++++++++++++++++++

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,7 @@ PyJWT==1.4.2
 peewee==2.8.5
 gunicorn==19.9.0
 pandas==0.24.2
+pronto==1.1.2
 
 ### This section is for the actual libraries ###
 # these libraries are imported in code that can be reached via

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@
 # the constraints file will point at the current master branch 
 # of the respective module.
 candig-common==1.0.0
-candig-schemas==1.0.0
+candig-schemas==1.0.1
 
 Werkzeug==0.15.5
 MarkupSafe==0.23
@@ -60,7 +60,7 @@ lxml==4.3.4
 pyBigWig==0.3.16
 
 # We need sphinx-argparse to build on readthedocs.
-sphinx-argparse==0.1.15
+sphinx-argparse
 
 # G2P uses a ttl backend
 RDFLib==4.2.1

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -75,6 +75,24 @@ class TestRepoManagerCli(unittest.TestCase):
         self.assertEqual(args.datasetName, self.datasetName)
         self.assertEqual(args.runner, "addDataset")
 
+    def testAddDatasetDuo(self):
+        cliInput = "add-dataset-duo {} {} {}".format(
+            self.registryPath, self.datasetName, self.filePath)
+        args = self.parser.parse_args(cliInput.split())
+        self.assertEqual(args.registryPath, self.registryPath)
+        self.assertEqual(args.datasetName, self.datasetName)
+        self.assertEqual(args.dataUseOntologyFile, self.filePath)
+        self.assertEqual(args.runner, "addDatasetDuo")
+
+    def testRemoveDatasetDuo(self):
+        cliInput = "remove-dataset-duo {} {} -f".format(
+            self.registryPath, self.datasetName)
+        args = self.parser.parse_args(cliInput.split())
+        self.assertEqual(args.registryPath, self.registryPath)
+        self.assertEqual(args.datasetName, self.datasetName)
+        self.assertEqual(args.runner, "removeDatasetDuo")
+        self.assertEqual(args.force, True)
+
     def testRemoveDataset(self):
         cliInput = "remove-dataset {} {} -f".format(
             self.registryPath, self.datasetName)

--- a/tests/unit/test_datasets.py
+++ b/tests/unit/test_datasets.py
@@ -15,6 +15,7 @@ class TestDatasets(unittest.TestCase):
         datasetId = 'ds1'
         dataset = datasets.SimulatedDataset(datasetId, 1, 2, 3, 4, 5)
         dataset.setAttributes({"test": "test"})
+        dataset.setDuoInfo([{"id": "DUO:0000042"}])
         gaDataset = dataset.toProtocolElement()
         self.assertIsNotNone(gaDataset.attributes.attr)
         self.assertEqual(


### PR DESCRIPTION
This PR introduces

- the ability to add DUO info to a dataset
- updated docs for DUO Ingestion
- updated specs for `/datasets/search` endpoint
- updated dependency (candig-server now requires candig-schema==1.0.1 due to the DUO info)

Note:
Parts of the `ontology` module are not used, as they were written for a DUO info retrieval API endpoint. This may be added in a future release.