### PR TITLE
update access list handling mechanism

### DIFF
--- a/candig/server/exceptions.py
+++ b/candig/server/exceptions.py
@@ -835,6 +835,19 @@ class MultipleReferenceSetsInReadGroupSet(MalformedException):
             "'{}'; at most one referenceSet per file is allowed.".format(
                 fileName, referenceSetName, otherReferenceSetName))
 
+
+class InvalidAccessListException(MalformedException):
+    """
+    The user has specified a non-supported access list level.
+    """
+    def __init__(self, level):
+        self.message = (
+            "You may only specify one of X, 0, 1, 2, 3, 4 to describe the "
+            "authorization level of a user, but you specified {} in your access_list.\n"
+            "Deprecation notice: if you still specify an empty value to indicate no access, "
+            "please change it to X, the support for empty value will be removed in the future release.".format(
+                level))
+
 # Internal errors. These are exceptions that we regard as bugs.
 
 

--- a/candig/server/frontend.py
+++ b/candig/server/frontend.py
@@ -264,10 +264,27 @@ class UserAccessMap(object):
         # Remove non set values
         self.user_access_map = {
             user: {project: level
-                   for project, level in value.items() if 0 <= level <= 4
+                   for project, level in value.items() if self.validateAccessLevel(level)
                    }
             for user, value in self.user_access_map.items()
         }
+
+    def validateAccessLevel(self, level):
+        """
+        Returns True if the level is one of 0, 1, 2, 3, 4, this indicates the user has some access to the dataset.
+        Returns False if the level is one of empty string or X, this indicates the user has no access to the dataset.
+        Raise an exception otherwise, this indicates that there's illegal characters specified as 'level'.
+
+        The support for empty string will be deprecated and removed in future releases.
+        """
+        try:
+            if 0 <= int(level) <= 4:
+                return True
+        except ValueError:
+            if level == "X" or level == "":
+                return False
+
+        raise exceptions.InvalidAccessListException(level)
 
     def getUserAccessMap(self, issuer, username):
         try:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -94,12 +94,18 @@ You can place your own access_list file anywhere you like, but you will need to 
 at `ACCESS_LIST`. Under production environment, you should define the location of the file
 to be somewhere secure.
 
+.. warning::
+
+    As of candig-server==1.2.1, using empty space to indicate that the user has no access to
+    a dataset has been deprecated, please use letter X instead.
+
+
 .. code-block:: text
 
     issuer	username	project1	project2	project3	projectN
 
     https://candigauth.bcgsc.ca/auth/realms/candig	userA	4	4	4	4
-    https://candigauth.bcgsc.ca/auth/realms/candig	userB	4		0	1
+    https://candigauth.bcgsc.ca/auth/realms/candig	userB	4	X	0	1
 
     https://candigauth.uhnresearch.ca/auth/realms/CanDIG	userC	4	3	2	1
-    https://candigauth.uhnresearch.ca/auth/realms/CanDIG	userD			4	4
+    https://candigauth.uhnresearch.ca/auth/realms/CanDIG	userD	X	X	4	4


### PR DESCRIPTION
This PR introduces the updated access list handling mechanism, as well as the corresponding part in the doc.

**Unchanged:**
- The roles of 5 different integer access levels are unmodified. These include 0, 1, 2, 3, 4.

**New:**
- "X" is introduced to indicate that the user has no access to the dataset.
- A strict check on authorization levels are conducted. Anything other than the acceptable values mentioned above will cause an exception to be thrown.

**Deprecates:**
- empty space ` ` to indicate that the user has no access to the dataset. Furthermore, this will be removed in future minor release of the candig-server.