### PR TITLE
fix a backend search request handling, and updated some docs

### DIFF
--- a/candig/server/backend.py
+++ b/candig/server/backend.py
@@ -253,7 +253,8 @@ class Backend(object):
             try:
                 for response in responses[logic[logic_key]]:
                     patient_id = self.getResponsePatientId(response, dataset_id)
-                    id_set.add(patient_id)
+                    if patient_id != "":
+                        id_set.add(patient_id)
                 if logic_negate:
                     id_list_all = self.getAllPatientId(dataset_id, access_map)
                     id_set = set(id_list_all) - id_set
@@ -281,7 +282,7 @@ class Backend(object):
 
     def getResponsePatientId(self, response, dataset_id):
         """
-        Gets the patientId from the response for object joins, otherwise throw error
+        Gets the patientId from the response for object joins, otherwise returns an empty string
         :param response:
         :param dataset_id:
         :return: patient id string
@@ -293,7 +294,7 @@ class Backend(object):
             variantSet = dataset.getVariantSet(response['variantSetId'])
             return variantSet.getPatientId()
         else:
-            raise exceptions.BadRequestException
+            return ""
 
     def variantComponentValidator(self, component):
         """

--- a/candig/server/ontology.py
+++ b/candig/server/ontology.py
@@ -112,7 +112,7 @@ class OntologyValidator():
         self.input_json = input_json
         self.ids_require_datetime_modifier = ["DUO:0000024"]
         self.ids_supported = [
-            "DUO:0000001", "DUO:0000002", "DUO:0000003", "DUO:0000004",
+            "DUO:0000001", "DUO:0000004",
             "DUO:0000005", "DUO:0000006", "DUO:0000007", "DUO:0000011",
             "DUO:0000012", "DUO:0000014", "DUO:0000015", "DUO:0000016",
             "DUO:0000017", "DUO:0000018", "DUO:0000019", "DUO:0000020",

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -96,8 +96,8 @@ to be somewhere secure.
 
 .. warning::
 
-    As of candig-server==1.2.1, using empty space to indicate that the user has no access to
-    a dataset has been deprecated, please use letter X instead.
+    As of candig-server==1.2.1, it is recommended that you use letter X to indicate that the
+    user has no access to a dataset, instead of an empty space.
 
 
 .. code-block:: text

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -142,7 +142,7 @@ of DUO's `raw OWL definition <https://github.com/EBISPOT/DUO/blob/master/src/ont
 .. warning::
     We only support a limited subset of the DUO terms.
 
-    Terms whose ID has an underscore, such as `DUO_0000031`, as well as `DUO:0000022` and `DUO:0000025` are not
+    Terms whose ID is between `DUO:0000031` and `DUO:0000039`, as well as `DUO:0000022` and `DUO:0000025` are not
     supported, as we expect these terms to be updated in the near future.
 
     If you think an ID should be supported, but is not. You can let us know by opening an issue
@@ -153,7 +153,7 @@ of DUO's `raw OWL definition <https://github.com/EBISPOT/DUO/blob/master/src/ont
 .. code-block:: json
 
     [
-        "DUO:0000001", "DUO:0000002", "DUO:0000003", "DUO:0000004", "DUO:0000005",
+        "DUO:0000001", "DUO:0000004", "DUO:0000005",
         "DUO:0000006", "DUO:0000007", "DUO:0000011", "DUO:0000012", "DUO:0000014",
         "DUO:0000015", "DUO:0000016", "DUO:0000017", "DUO:0000018", "DUO:0000019",
         "DUO:0000020", "DUO:0000021", "DUO:0000024", "DUO:0000026", "DUO:0000027"

--- a/docs/status.rst
+++ b/docs/status.rst
@@ -7,9 +7,41 @@ Status
 Please refer to https://github.com/CanDIG/candig-server/releases for the latest release
 notes.
 
-+++++++++++++
-Release Notes
-+++++++++++++
+++++++++++++++++++
+Upgrade Guidelines
+++++++++++++++++++
+
+This section is mainly prepared for system administrators.
+
+*****
+1.2.1
+*****
+
+Release note available from https://github.com/CanDIG/candig-server/releases/tag/v1.2.1
+
+----
+
+As indicated in the release note, ``X`` is now used to indicate no access. You may see a newly-updated
+sample access_list file from :ref:`configuration`.
+
+If you have used empty space to indicate no access, you should:
+
+- Step 1: Update the candig-server in your virtual environment to v1.2.1.
+- Step 2: Replace all empty space with X.
+
+You should always restart the candig-server service when you update to a new candig-server.
+
+----
+
+As indicated in the release note, ``DUO:0000002`` and ``DUO:0000003`` are no longer valid DUO
+ids.
+
+If you have specified one of these two for one or more of your datasets, you should
+
+- Step 1: Remove ``DUO:0000002`` and ``DUO:0000003`` from the json file that holds info regarding your data use restrictions.
+- Step 2: Re-run the ``add-dataset-duo`` command.
+
+You should restart the candig-server service when you make changes to the data.
 
 *****
 1.2.0


### PR DESCRIPTION
This PR introduces:

**Bug fixes**:
- Currently, some valid queries made to the /search and /count endpoint are deemed 400, as a BadRequestException was incorrectly thrown. This usually only happens when the access_level is set to something below 4, meaning partial access to the data.

**Ontology**:
- `DUO:0000002` and `DUO:0000003` have now been removed from the acceptable list of DUO ids, relevant docs have been updated. This is due to a new release from DUO.

**Docs**:
- The docs have been updated, including the upgrade guideline for the upcoming v1.2.1 release.