### PR TITLE
Added missing -r flag in pip command

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -24,7 +24,7 @@ and run
 .. code-block:: bash
 
     pip clone https://github.com/CanDIG/candig-server.git
-    pip install dev-requirements.txt
+    pip install -r dev-requirements.txt
 
 The default DB location for development server is `candig-example-data/registry.db`.
 


### PR DESCRIPTION
The pip install command was missing "-r" flag resulting in the follow error message:
```
ERROR: Could not find a version that satisfies the requirement dev-requirements.txt (from versions: none)
ERROR: No matching distribution found for dev-requirements.txt
```
This commit fixed this error.