### PR TITLE
typos fix on documentation

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,7 +6,7 @@ API Usage & Sample Queries
 
 .. warning::
 
-    This guide is a work in progress, and is incomplete.
+    This guide is a work in progress, and it is incomplete.
 
 
 This section will provide instructions on API usages. Upon logging in, you will see a

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -4,7 +4,7 @@
 Production Deployment
 *********************
 
-The candig-server has a  `Configuration file`_. allows Flask and application
+The candig-server has a  `Configuration file`_ that allows Flask and application
 specific configuration values to be set.
 
 ------------------

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -32,7 +32,7 @@ data, its key is `pipeline_metadata`. Make sure you have the correct key specifi
 
 The value of the key is a list of objects. Each object should have the table name as the
 key, and the object as its value. Therefore, it is possible to specify multiple tables in
-one single object. However, each table can only specified once, due to the uniqueness of
+one single object. However, each table can only be specified once, due to the uniqueness of
 the key in the object.
 
 If you need to specify, for example, two samples for one patient. You should specify the

--- a/docs/datarepo.rst
+++ b/docs/datarepo.rst
@@ -1091,7 +1091,7 @@ named ``1KG`` from the repository represented by ``registry.db``.
 remove-rnaquantificationset
 ---------------------------
 
-Removes a rna quantification set from the repository.
+Removes a RNA quantification set from the repository.
 
 .. argparse::
    :module: candig.server.cli.repomanager

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -96,7 +96,7 @@ For server B, you need to run
     candig_repo add-peer candig-example-data/registry.db http://0.0.0.0:3000
 
 You do not need to have anything running on the peer when you execute the `add-peer` command.
-It simply registeres that URL as a peer.
+It simply registers that URL as a peer.
 
 Now, you will get federated response
 from both servers A and B. You can certainly choose to run them on different ports, or different

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -93,7 +93,7 @@ For server B, you need to run
 
 .. code-block:: bash
 
-    candig_repo add-peer candig-example-data/registry.db http://0.0.0.0:3001
+    candig_repo add-peer candig-example-data/registry.db http://0.0.0.0:3000
 
 You do not need to have anything running on the peer when you execute the `add-peer` command.
 It simply registeres that URL as a peer.


### PR DESCRIPTION
On ```Development Setup``` page, the port on the following command should be ```3000```, which is the port for ```Server A```. This pull request is fixing it.
```
candig_repo add-peer candig-example-data/registry.db http://0.0.0.0:3001
```
Also fixed some typos accross the documentation.