### PR TITLE
Removed mock from dev-req and fixed code

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,7 +16,6 @@ PyYAML==5.1
 # do not import them in any code that can be reached via 
 # an executable that we ship
 
-mock
 nose
 pep8
 flake8==3.2.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ import shlex
 
 # this next section is a hack to get the build to work on RTD; see:
 # http://docs.readthedocs.io/en/latest/faq.html#i-get-import-errors-on-libraries-that-depend-on-c-modules
-from mock import MagicMock
+from unittest.mock import MagicMock
 
 class Mock(MagicMock):
     @classmethod

--- a/tests/end_to_end/test_repo_manager.py
+++ b/tests/end_to_end/test_repo_manager.py
@@ -2,7 +2,7 @@
 End to end test that invokes the repo manager
 """
 
-import mock
+from unittest import mock
 import os
 import tempfile
 import unittest

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -2,7 +2,7 @@
 Tests related to exceptions
 """
 
-import mock
+from unittest import mock
 import unittest
 import inspect
 


### PR DESCRIPTION
**Improvements**
- Major
Removed _mock_ from the dependencies file. Using one from Python Standard Library.