### PR TITLE
updates (Dockerfile): extra mkdir removal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN cd /tmp/server/ && pip install .
 
 RUN mkdir /data
 WORKDIR /data
-RUN mkdir  mkdir candig-example-data \
+RUN mkdir candig-example-data \
   && touch access_list.tsv
 
 RUN curl -Lo /tmp/mock_data.json  https://github.com/CanDIG/candig-ingest/releases/download/${INGEST_V}/mock_data.json \


### PR DESCRIPTION
An extra `mkdir` argument in the `mkdir` command generates extra directory called `mkdir`.