### PR TITLE
Don't assume that the referenceName is not of the "chr_" format

### DIFF
--- a/candig/server/backend.py
+++ b/candig/server/backend.py
@@ -2833,7 +2833,7 @@ class Backend(object):
             for feature in featureset.getFeatures(geneSymbol=request.gene, featureTypes=["gene"]):
                 for variantset in processedVariantsets:
                     for variant in variantset.getVariants(
-                            referenceName=feature.reference_name.replace('chr', ''),
+                            referenceName=feature.reference_name,
                             startPosition=feature.start,
                             endPosition=feature.end,
                     ):


### PR DESCRIPTION
Apparently the variantsGeneSearchHelper code assumes, because the GSC files usually did it this way, that the variantSets would actually have their references in the format "#" instead of "chr#", so it replaces the "chr" by default. However, this isn't correct for the INSPIRE dataset. Jimmy is going to look into whether or not any current files at GSC really do use the "#" format still.