### PR TITLE
Add Experimental Support for OPA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,8 @@ tests/data/registry.db
 *.tar
 *.zip
 *.whl
- 
+*.bgz
+
 # Logs and databases #
 ######################
 *.log
@@ -129,3 +130,4 @@ oidc-provider/simple_op/src/provider/server/static/jwks.json
 # misc. project test data related
 clinical_metadata_tier*.json*
 data
+.python-version

--- a/candig/server/frontend.py
+++ b/candig/server/frontend.py
@@ -962,7 +962,7 @@ def handleException(exception):
 
 @app.before_request
 def checkAuthorization():
-    if app.config.get("TYK_ENABLED") and not app.config.get("OPA_SERVER")::
+    if app.config.get("TYK_ENABLED") and not app.config.get("OPA_SERVER"):
         if app.access_map.getListUpdated() != os.path.getmtime(app.access_map.getFilePath()):
             if app.logger:
                 app.logger.info(

--- a/candig/server/frontend.py
+++ b/candig/server/frontend.py
@@ -667,6 +667,8 @@ class FederationResponse(object):
 
                 if app.config.get("OPA_SERVER"):
                     # TODO: Call OPA server to get access map
+                    # A sample access_map looks like this: {"dataset1": 4, "dataset2": 4}
+                    # All datasets from OPA are given access level 4
                     pass
                 else:
                     access_map = app.access_map.getUserAccessMap(issuer, username)

--- a/candig/server/frontend.py
+++ b/candig/server/frontend.py
@@ -685,7 +685,7 @@ class FederationResponse(object):
                         'Content-Type': 'application/json'
                     }
                     response = requests.request("POST", app.config.get("OPA_SERVER"), headers=headers, data=payload)
-                    res_datasets = response.json()["results"]
+                    res_datasets = response.json()["result"]
                     for i in res_datasets:
                         access_map[i] = 4
                 else:
@@ -962,7 +962,7 @@ def handleException(exception):
 
 @app.before_request
 def checkAuthorization():
-    if app.config.get("TYK_ENABLED"):
+    if app.config.get("TYK_ENABLED") and not app.config.get("OPA_SERVER")::
         if app.access_map.getListUpdated() != os.path.getmtime(app.access_map.getFilePath()):
             if app.logger:
                 app.logger.info(

--- a/candig/server/frontend.py
+++ b/candig/server/frontend.py
@@ -683,6 +683,7 @@ class FederationResponse(object):
                     }
                     response = requests.request("POST", app.config.get("OPA_SERVER"), headers=headers, data=payload)
                     res_datasets = response.json()["result"]
+                    #all datasets returned by OPA are assigned access level 4
                     for i in res_datasets:
                         access_map[i] = 4
                 else:

--- a/candig/server/frontend.py
+++ b/candig/server/frontend.py
@@ -664,7 +664,13 @@ class FederationResponse(object):
                 parsed_payload = _parseTokenPayload(access_token)
                 issuer = parsed_payload.get('iss')
                 username = parsed_payload.get('preferred_username')
-                access_map = app.access_map.getUserAccessMap(issuer, username)
+
+                if app.config.get("OPA_SERVER"):
+                    # TODO: Call OPA server to get access map
+                    pass
+                else:
+                    access_map = app.access_map.getUserAccessMap(issuer, username)
+
             else:
                 raise exceptions.NotAuthenticatedException
         else:

--- a/candig/server/frontend.py
+++ b/candig/server/frontend.py
@@ -499,7 +499,7 @@ def configure(configFile=None, baseConfig="ProductionConfig",
             app.oidcClient.store_registration_info(response)
 
     # Set user access map from file if using a gateway to authenticate
-    if app.config.get("TYK_ENABLED"):
+    if app.config.get("TYK_ENABLED") and not app.config.get("OPA_SERVER"):
         load_access_map()
 
 

--- a/candig/server/frontend.py
+++ b/candig/server/frontend.py
@@ -683,7 +683,7 @@ class FederationResponse(object):
                     }
                     response = requests.request("POST", app.config.get("OPA_SERVER"), headers=headers, data=payload)
                     res_datasets = response.json()["result"]
-                    #all datasets returned by OPA are assigned access level 4
+                    # all datasets returned by OPA are assigned access level 4
                     for i in res_datasets:
                         access_map[i] = 4
                 else:

--- a/candig/server/frontend.py
+++ b/candig/server/frontend.py
@@ -666,22 +666,19 @@ class FederationResponse(object):
                 username = parsed_payload.get('preferred_username')
 
                 if app.config.get("OPA_SERVER"):
-                    # TODO: Call OPA server to get access map
-                    # A sample access_map looks like this: {"dataset1": 4, "dataset2": 4}
-                    # All datasets from OPA are given access level 4
                     payload = json.dumps({
                         "input": {
                             "headers": {
-                            "X-Candig-Local-Oidc": access_token.split(' ')[1]
+                                "X-Candig-Local-Oidc": access_token.split(' ')[1]
                             },
                             "method": "GET",
                             "path": [
-                            "beacon"
+                                "beacon"
                             ]
                         }
                     })
                     headers = {
-                        'Authorization': 'Bearer my-secret-beacon-token',
+                        'Authorization': 'Bearer ' + app.config.get("OPA_SERVER_TOKEN"),
                         'Content-Type': 'application/json'
                     }
                     response = requests.request("POST", app.config.get("OPA_SERVER"), headers=headers, data=payload)

--- a/candig/server/frontend.py
+++ b/candig/server/frontend.py
@@ -669,7 +669,25 @@ class FederationResponse(object):
                     # TODO: Call OPA server to get access map
                     # A sample access_map looks like this: {"dataset1": 4, "dataset2": 4}
                     # All datasets from OPA are given access level 4
-                    pass
+                    payload = json.dumps({
+                        "input": {
+                            "headers": {
+                            "X-Candig-Local-Oidc": "??????"
+                            },
+                            "method": "GET",
+                            "path": [
+                            "beacon"
+                            ]
+                        }
+                    })
+                    headers = {
+                        'Authorization': 'Bearer my-secret-beacon-token',
+                        'Content-Type': 'application/json'
+                    }
+                    response = requests.request("POST", app.config.get("OPA_SERVER"), headers=headers, data=payload)
+                    res_datasets = response.json()["results"]
+                    for i in res_datasets:
+                        access_map[i] = 4
                 else:
                     access_map = app.access_map.getUserAccessMap(issuer, username)
 

--- a/candig/server/frontend.py
+++ b/candig/server/frontend.py
@@ -672,7 +672,7 @@ class FederationResponse(object):
                     payload = json.dumps({
                         "input": {
                             "headers": {
-                            "X-Candig-Local-Oidc": "??????"
+                            "X-Candig-Local-Oidc": access_token.split(' ')[1]
                             },
                             "method": "GET",
                             "path": [

--- a/candig/server/serverconfig.py
+++ b/candig/server/serverconfig.py
@@ -197,10 +197,15 @@ class TykConfig(KeycloakOidConfig):
     If OPA_SERVER is set, it will be used as source of access_map instead of ACCESS_LIST.
     OPA_SERVER link needs to be the OPA's address plus the '/data/permissions/datasets'
     For example, OPA_SERVER = 'http://localhost:8000/v1/data/permissions/datasets'.
+    OPA_SERVER_TOKEN needs to be set to the same secret token in OPA in order to be 
+    authorized to visit the OPA dataset permission endpoint.
+    For example, OPA_SERVER_TOKEN = my-secret-beacon-token.
+    
     To start a dev flask server using this config add in launch option, -c TykConfig
+    
     """
     OPA_SERVER = None
-    OPA_SERVER_TOKEN = 'my-secret-beacon-token'
+    OPA_SERVER_TOKEN = ''
     ACCESS_LIST = "access_list.txt"
 
     TYK_ENABLED = True

--- a/candig/server/serverconfig.py
+++ b/candig/server/serverconfig.py
@@ -198,7 +198,7 @@ class TykConfig(KeycloakOidConfig):
 
     To start a dev flask server using this config add in launch option, -c TykConfig
     """
-    OPA_SERVER = None
+    OPA_SERVER = 'http://localhost:8000/v1/data/permissions/datasets'
     ACCESS_LIST = "access_list.txt"
 
     TYK_ENABLED = True

--- a/candig/server/serverconfig.py
+++ b/candig/server/serverconfig.py
@@ -199,10 +199,8 @@ class TykConfig(KeycloakOidConfig):
     For example, OPA_SERVER = 'http://localhost:8000/v1/data/permissions/datasets'.
     OPA_SERVER_TOKEN needs to be set to the same secret token in OPA in order to be 
     authorized to visit the OPA dataset permission endpoint.
-    For example, OPA_SERVER_TOKEN = my-secret-beacon-token.
     
     To start a dev flask server using this config add in launch option, -c TykConfig
-    
     """
     OPA_SERVER = None
     OPA_SERVER_TOKEN = ''

--- a/candig/server/serverconfig.py
+++ b/candig/server/serverconfig.py
@@ -195,7 +195,7 @@ class TykConfig(KeycloakOidConfig):
     This also requires that keycloak config is being used and is set up properly.
 
     If OPA_SERVER is set, it will be used as source of access_map instead of ACCESS_LIST.
-    OPA_SERVER link needs to be the OPA's address plus the '/data/permissions/datasets'
+    OPA_SERVER link needs to be the OPA's address plus the '/v1/data/permissions/datasets'
     For example, OPA_SERVER = 'http://localhost:8000/v1/data/permissions/datasets'.
     OPA_SERVER_TOKEN needs to be set to the same secret token in OPA in order to be 
     authorized to visit the OPA dataset permission endpoint.

--- a/candig/server/serverconfig.py
+++ b/candig/server/serverconfig.py
@@ -195,10 +195,12 @@ class TykConfig(KeycloakOidConfig):
     This also requires that keycloak config is being used and is set up properly.
 
     If OPA_SERVER is set, it will be used as source of access_map instead of ACCESS_LIST.
-
+    OPA_SERVER link needs to be the OPA's address plus the '/data/permissions/datasets'
+    For example, OPA_SERVER = 'http://localhost:8000/v1/data/permissions/datasets'.
     To start a dev flask server using this config add in launch option, -c TykConfig
     """
-    OPA_SERVER = 'http://localhost:8000/v1/data/permissions/datasets'
+    OPA_SERVER = None
+    OPA_SERVER_TOKEN = 'my-secret-beacon-token'
     ACCESS_LIST = "access_list.txt"
 
     TYK_ENABLED = True

--- a/candig/server/serverconfig.py
+++ b/candig/server/serverconfig.py
@@ -194,8 +194,11 @@ class TykConfig(KeycloakOidConfig):
     Configuration to use when forwarding requests through the API gateway.
     This also requires that keycloak config is being used and is set up properly.
 
+    If OPA_SERVER is set, it will be used as source of access_map instead of ACCESS_LIST.
+
     To start a dev flask server using this config add in launch option, -c TykConfig
     """
+    OPA_SERVER = None
     ACCESS_LIST = "access_list.txt"
 
     TYK_ENABLED = True


### PR DESCRIPTION
Adding opa configuration and before every request gets processed, the user token will be forwarded to opa and check the user's dataset permissions if OPA_SERVER is enabled.